### PR TITLE
Implement streaming parser generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+v0.4 – streaming parser
+-----------------------
+- Added `iter_parsed_frames` generator yielding DataFrame chunks.
+- Added `parse_pcap_to_df` helper for old behaviour and updated `parse_pcap` to wrap it.
+- Exported new API in package `__init__`.

--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -1,5 +1,16 @@
 # src/pcap_tool/__init__.py
-from .parser import parse_pcap, PcapRecord
+from .parser import (
+    parse_pcap,
+    parse_pcap_to_df,
+    iter_parsed_frames,
+    PcapRecord,
+)
 from .pdf_report import generate_pdf_report
 
-__all__ = ["parse_pcap", "PcapRecord", "generate_pdf_report"]
+__all__ = [
+    "parse_pcap",
+    "parse_pcap_to_df",
+    "iter_parsed_frames",
+    "PcapRecord",
+    "generate_pdf_report",
+]

--- a/src/pcap_tool/parser.py
+++ b/src/pcap_tool/parser.py
@@ -1,10 +1,21 @@
 # src/pcap_tool/parser.py
 from dataclasses import dataclass, asdict
-from typing import Optional, Generator, List, Any # Added Any
+from typing import (
+    Optional,
+    Generator,
+    List,
+    Any,
+    IO,
+    Iterator,
+    Callable,
+)
 import logging
 import pandas as pd
 from pathlib import Path
 import ipaddress
+import subprocess
+import tempfile
+import os
 
 logger = logging.getLogger(__name__)
 
@@ -628,13 +639,43 @@ def _parse_with_pcapkit(file_path: str, max_packets: Optional[int]) -> Generator
     logger.info("PCAPKit: Processing complete (stubbed).")
     return # Or raise StopIteration implicitly
 
-def parse_pcap(file_path: str, max_packets: Optional[int] = None) -> pd.DataFrame:
+
+def _ensure_path(file_like: Path | IO[bytes]) -> tuple[Path, bool]:
+    """Return a file system Path for ``file_like``.
+
+    If ``file_like`` is an open binary stream, its contents are written to a
+    temporary file which is then returned.  The second element of the tuple
+    indicates whether the caller should delete the path when finished.
+    """
+    if isinstance(file_like, (str, os.PathLike, Path)):
+        return Path(file_like), False
+
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    tmp.write(file_like.read())
+    tmp.flush()
+    tmp.close()
+    return Path(tmp.name), True
+
+
+def _estimate_total_packets(path: Path) -> Optional[int]:
+    """Estimate number of packets using ``capinfos -c`` if available."""
+    try:
+        out = subprocess.check_output(["capinfos", "-c", str(path)], text=True)
+        for line in out.splitlines():
+            if "Number of packets" in line:
+                return int(line.split(":")[-1].strip())
+    except Exception as exc:  # pragma: no cover - best effort only
+        logger.debug("capinfos failed: %s", exc)
+    return None
+
+
+def _get_record_generator(file_path: str, max_packets: Optional[int]) -> tuple[Optional[Generator[PcapRecord, None, None]], str]:
+    """Return a generator yielding :class:`PcapRecord` objects."""
     if not _USE_PYSHARK and not _USE_PCAPKIT:
         err_msg = "Neither PyShark nor PCAPKit is installed or available. Please install at least one."
         logger.critical(err_msg)
         raise RuntimeError(err_msg)
 
-    records_list: List[PcapRecord] = []
     record_generator: Optional[Generator[PcapRecord, None, None]] = None
     parser_used = "None"
 
@@ -644,7 +685,7 @@ def parse_pcap(file_path: str, max_packets: Optional[int] = None) -> pd.DataFram
         try:
             record_generator = _parse_with_pyshark(file_path, max_packets)
         except RuntimeError as e_pyshark_init:
-            logger.warning(f"PyShark primary parser failed: {e_pyshark_init}")
+            logger.warning("PyShark primary parser failed: %s", e_pyshark_init)
             if not _USE_PCAPKIT:
                 logger.error("PyShark failed and PCAPKit fallback is not available. Cannot parse file.")
                 raise
@@ -652,7 +693,7 @@ def parse_pcap(file_path: str, max_packets: Optional[int] = None) -> pd.DataFram
             record_generator = None
             parser_used = "PCAPKit_Fallback_After_PyShark_Error"
         except Exception as e_pyshark_generic:
-            logger.error(f"An unexpected error occurred with PyShark: {e_pyshark_generic}", exc_info=True)
+            logger.error("An unexpected error occurred with PyShark: %s", e_pyshark_generic, exc_info=True)
             if not _USE_PCAPKIT:
                 logger.error("PyShark failed and PCAPKit fallback is not available.")
                 raise
@@ -660,49 +701,95 @@ def parse_pcap(file_path: str, max_packets: Optional[int] = None) -> pd.DataFram
             record_generator = None
             parser_used = "PCAPKit_Fallback_After_PyShark_Error"
 
-    if record_generator is None and _USE_PCAPKIT: # Fallback or if PyShark was not used
-        if parser_used != "PCAPKit_Fallback_After_PyShark_Error": # Avoid double logging if PyShark failed
-             logger.info("PyShark not used or available. Attempting to parse with PCAPKit...")
+    if record_generator is None and _USE_PCAPKIT:
+        if parser_used != "PCAPKit_Fallback_After_PyShark_Error":
+            logger.info("PyShark not used or available. Attempting to parse with PCAPKit...")
         parser_used = "PCAPKit"
         try:
             record_generator = _parse_with_pcapkit(file_path, max_packets)
         except FileNotFoundError:
-            logger.error(f"PCAPKit error: File not found at {file_path}")
+            logger.error("PCAPKit error: File not found at %s", file_path)
             raise
         except Exception as e_pcapkit:
-            logger.error(f"PCAPKit failed to process the file: {e_pcapkit}", exc_info=True)
-            # Avoid raising here if PyShark was the primary attempt and failed, let it be handled by lack of records
-            # However, if PCAPKit was the only option, then raise
-            if not _USE_PYSHARK: # Only raise if PCAPKit was the primary and only option
-                 raise RuntimeError(f"PCAP parsing failed with {parser_used} for {file_path}.") from e_pcapkit
+            logger.error("PCAPKit failed to process the file: %s", e_pcapkit, exc_info=True)
+            if not _USE_PYSHARK:
+                raise RuntimeError(f"PCAP parsing failed with {parser_used} for {file_path}.") from e_pcapkit
 
-    if record_generator:
-        logger.info(f"Collecting records using {parser_used}...")
-        try:
-            for record_idx, record in enumerate(record_generator):
-                records_list.append(record)
-                if max_packets is not None and len(records_list) >= max_packets:
-                    break
-        except Exception as e_gen:
-            logger.error(f"Error consuming from record generator ({parser_used}): {e_gen}", exc_info=True)
+    return record_generator, parser_used
 
-        logger.info(f"Collected {len(records_list)} records using {parser_used}.")
-    else:
-        # This condition might be hit if PyShark was available but failed, and PCAPKit was also not available or failed silently.
-        if not (_USE_PYSHARK and parser_used == "PyShark") and \
-           not (_USE_PCAPKIT and parser_used.startswith("PCAPKit")): # Ensure some parser was supposed to run
-             logger.error("No valid parser (PyShark or PCAPKit) was successfully initiated or yielded records.")
-             # No raise here, let it return empty DF to be handled by caller, but log it as error.
 
-    if not records_list:
-        logger.warning(f"No records were parsed from '{file_path}' using {parser_used}. Returning an empty DataFrame.")
-        # Ensure DataFrame has all columns even if empty
-        all_field_names = [f.name for f in PcapRecord.__dataclass_fields__.values()]
-        return pd.DataFrame(columns=all_field_names)
+def iter_parsed_frames(
+    file_like: Path | IO[bytes],
+    chunk_size: int = 10_000,
+    on_progress: Callable[[int, Optional[int]], None] | None = None,
+    max_packets: int | None = None,
+) -> Iterator[pd.DataFrame]:
+    """Yield parsed packets as ``pandas`` DataFrame chunks."""
 
-    df = pd.DataFrame([asdict(r) for r in records_list])
-    logger.info(f"Successfully parsed {len(df)} records into a DataFrame using {parser_used}.")
-    return df
+    path, cleanup = _ensure_path(file_like)
+    total_estimate = _estimate_total_packets(path)
+
+    record_generator, parser_used = _get_record_generator(str(path), max_packets)
+
+    if record_generator is None:
+        logger.error("No valid parser (PyShark or PCAPKit) was successfully initiated or yielded records.")
+        cols = [f.name for f in PcapRecord.__dataclass_fields__.values()]
+        yield pd.DataFrame(columns=cols)
+        if cleanup:
+            os.unlink(path)
+        return
+
+    rows: List[dict] = []
+    count = 0
+    next_callback = 100
+
+    try:
+        for record in record_generator:
+            rows.append(asdict(record))
+            count += 1
+            if on_progress and count >= next_callback:
+                on_progress(count, total_estimate)
+                next_callback = count + 100
+            if len(rows) >= chunk_size:
+                if on_progress:
+                    on_progress(count, total_estimate)
+                yield pd.DataFrame(rows)
+                rows.clear()
+            if max_packets is not None and count >= max_packets:
+                break
+    finally:
+        if cleanup:
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    if rows:
+        if on_progress:
+            on_progress(count, total_estimate)
+        yield pd.DataFrame(rows)
+    elif count == 0:
+        cols = [f.name for f in PcapRecord.__dataclass_fields__.values()]
+        yield pd.DataFrame(columns=cols)
+
+
+def parse_pcap_to_df(
+    file_like: Path | IO[bytes],
+    chunk_size: int = 10_000,
+    on_progress: Callable[[int, Optional[int]], None] | None = None,
+    max_packets: int | None = None,
+) -> pd.DataFrame:
+    """Parse ``file_like`` and return a single concatenated ``DataFrame``."""
+
+    chunks = list(iter_parsed_frames(file_like, chunk_size=chunk_size, on_progress=on_progress, max_packets=max_packets))
+    if not chunks:
+        cols = [f.name for f in PcapRecord.__dataclass_fields__.values()]
+        return pd.DataFrame(columns=cols)
+    return pd.concat(chunks, ignore_index=True)
+
+def parse_pcap(file_path: str, max_packets: Optional[int] = None) -> pd.DataFrame:
+    """Backward compatible wrapper returning a single DataFrame."""
+    return parse_pcap_to_df(Path(file_path), max_packets=max_packets)
 
 if __name__ == '__main__':
     logging.basicConfig(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,3 +6,12 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 SRC_PATH = PROJECT_ROOT / "src"
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
+
+
+import pytest
+
+
+@pytest.fixture
+def example_pcap() -> Path:
+    """Return path to a small example pcap for tests."""
+    return PROJECT_ROOT / "tests" / "fixtures" / "mini.pcapng"

--- a/tests/test_iter_frames.py
+++ b/tests/test_iter_frames.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from pcap_tool.parser import iter_parsed_frames
+
+
+def test_iter_frames_chunking(example_pcap):
+    chunks = list(iter_parsed_frames(example_pcap, chunk_size=5))
+    assert len(chunks) >= 2
+    assert all(df.shape[0] <= 5 for df in chunks)


### PR DESCRIPTION
## Summary
- add `iter_parsed_frames` streaming generator
- support old behaviour via `parse_pcap_to_df`
- export new API in package init
- include CHANGELOG entry
- test chunking behaviour with new example fixture

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: test_zscaler_policy_block, test_tls_sni_extraction, test_tls_non_standard_port)*