### PR TITLE
Add optional multiprocessing parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,8 @@ These changes keep the codebase production-ready while letting you run everythin
 
 ```bash
 pytest
+```
+
+### Multiprocessing Parser
+
+`iter_parsed_frames` uses multiple processes by default to speed up large PCAP files. Pass `workers=0` to disable multiprocessing; otherwise up to four processes are used.

--- a/tests/test_iter_frames.py
+++ b/tests/test_iter_frames.py
@@ -6,3 +6,13 @@ def test_iter_frames_chunking(example_pcap):
     chunks = list(iter_parsed_frames(example_pcap, chunk_size=5))
     assert len(chunks) >= 2
     assert all(df.shape[0] <= 5 for df in chunks)
+
+
+def test_multiprocessing_order(example_pcap):
+    single = list(iter_parsed_frames(example_pcap, chunk_size=2, workers=0))
+    numbers_single = [n for df in single for n in df["frame_number"].tolist()]
+
+    multi = list(iter_parsed_frames(example_pcap, chunk_size=2, workers=2))
+    numbers_multi = [n for df in multi for n in df["frame_number"].tolist()]
+
+    assert numbers_multi == numbers_single


### PR DESCRIPTION
## Summary
- implement optional multiprocessing in `iter_parsed_frames`
- expose `workers` param through parsing helpers
- add worker helper for slice parsing
- document multiprocessing in README
- test order preservation across workers

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: test_zscaler_policy_block, test_tls_sni_extraction, test_tls_non_standard_port)*