### PR TITLE
Add on-disk storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,12 @@ pytest
 ### Multiprocessing Parser
 
 `iter_parsed_frames` uses multiple processes by default to speed up large PCAP files. Pass `workers=0` to disable multiprocessing; otherwise up to four processes are used.
+
+### Command-Line Parsing
+
+Parse a capture directly to DuckDB for ad-hoc SQL:
+
+```bash
+pcap-tool parse big.pcap --output duckdb://big.db
+duckdb big.db "SELECT tunnel_type, COUNT(*) FROM flows GROUP BY 1;"
+```

--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -4,6 +4,7 @@ from .parser import (
     parse_pcap_to_df,
     iter_parsed_frames,
     PcapRecord,
+    ParsedHandle,
 )
 from .pdf_report import generate_pdf_report
 
@@ -12,5 +13,6 @@ __all__ = [
     "parse_pcap_to_df",
     "iter_parsed_frames",
     "PcapRecord",
+    "ParsedHandle",
     "generate_pdf_report",
 ]

--- a/src/pcap_tool/__main__.py
+++ b/src/pcap_tool/__main__.py
@@ -1,0 +1,23 @@
+import argparse
+from pathlib import Path
+
+from .parser import parse_pcap
+
+
+def main():
+    parser = argparse.ArgumentParser(description="PCAP utility")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    parse_cmd = sub.add_parser("parse", help="parse a pcap")
+    parse_cmd.add_argument("pcap")
+    parse_cmd.add_argument("--output", dest="output_uri", help="duckdb://file.db or arrow://dir")
+    args = parser.parse_args()
+
+    if args.cmd == "parse":
+        handle = parse_pcap(Path(args.pcap), output_uri=args.output_uri)
+        print(f"Parsed {handle.count()} flows")
+        if args.output_uri is None:
+            print(handle.as_dataframe().head())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+import resource
+import pytest
+from scapy.layers.l2 import Ether
+from scapy.layers.inet import IP, TCP
+from scapy.utils import PcapWriter
+
+from pcap_tool.parser import parse_pcap
+
+
+def _make_big_pcap(path: Path, count: int):
+    packets = [Ether()/IP(src="10.0.0.1", dst="10.0.0.2")/TCP(sport=1, dport=2) for _ in range(count)]
+    for i, pkt in enumerate(packets):
+        pkt.time = float(i)
+    with PcapWriter(str(path), sync=True) as writer:
+        for pkt in packets:
+            writer.write(pkt)
+
+
+def _rss_mb() -> float:
+    r = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    if sys.platform == "darwin":
+        return r / (1024 * 1024)
+    return r / 1024
+
+
+@pytest.mark.skipif(pytest.importorskip("duckdb", reason="duckdb not installed") is None, reason="duckdb not installed")
+def test_duckdb_output_memory(tmp_path):
+    pcap_path = tmp_path / "big.pcap"
+    _make_big_pcap(pcap_path, 100_000)
+    handle = parse_pcap(pcap_path, output_uri="duckdb://:memory:", workers=0)
+    assert handle.count() == 100_000
+    assert _rss_mb() < 500


### PR DESCRIPTION
## Summary
- allow fallback to PCAPKit if PyShark fails
- store parsed flows in DuckDB or Arrow via new `ParsedHandle`
- expose simple CLI with `pcap-tool parse`
- document DuckDB workflow in README
- adapt tests to new API and add duckdb memory test

## Testing
- `pytest -q`
- `flake8 src/ tests/`