### PR TITLE
Add Excel summary export

### DIFF
--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -7,7 +7,7 @@ from .parser import (
     ParsedHandle,
 )
 from .pdf_report import generate_pdf_report
-from .summary import generate_summary_df
+from .summary import generate_summary_df, export_summary_excel
 
 __all__ = [
     "parse_pcap",
@@ -17,4 +17,5 @@ __all__ = [
     "ParsedHandle",
     "generate_pdf_report",
     "generate_summary_df",
+    "export_summary_excel",
 ]

--- a/tests/test_summary_excel.py
+++ b/tests/test_summary_excel.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import pytest
+from io import BytesIO
+
+from pcap_tool.summary import export_summary_excel
+
+
+def test_export_summary_excel_basic():
+    df = pd.DataFrame({
+        'protocol': ['TCP', 'UDP', 'TCP'],
+        'src_ip': ['1.1.1.1', '2.2.2.2', '1.1.1.1'],
+    })
+    buffer = BytesIO()
+    try:
+        export_summary_excel(df, buffer)
+    except ImportError:
+        pytest.skip("Excel writer not installed")
+    buffer.seek(0)
+    excel = pd.ExcelFile(buffer)
+    assert set(excel.sheet_names) == {'TCP', 'UDP'}


### PR DESCRIPTION
## Summary
- add `export_summary_excel` to write protocol sheets to Excel
- expose new function in package `__all__`
- test Excel export behaviour

## Testing
- `flake8 src/ tests/`
- `pytest -q`