### PR TITLE
Add PerformanceAnalyzer for TCP metrics

### DIFF
--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -10,6 +10,7 @@ from .pdf_report import generate_pdf_report
 from .summary import generate_summary_df, export_summary_excel
 from .metrics.stats_collector import StatsCollector
 from .enrichment import Enricher
+from .analyze import PerformanceAnalyzer
 
 
 __all__ = [
@@ -23,5 +24,5 @@ __all__ = [
     "export_summary_excel",
     "StatsCollector",
     "Enricher",
-
+    "PerformanceAnalyzer",
 ]

--- a/src/pcap_tool/analyze/__init__.py
+++ b/src/pcap_tool/analyze/__init__.py
@@ -1,0 +1,2 @@
+from .performance_analyzer import PerformanceAnalyzer
+__all__ = ["PerformanceAnalyzer"]

--- a/src/pcap_tool/analyze/performance_analyzer.py
+++ b/src/pcap_tool/analyze/performance_analyzer.py
@@ -1,0 +1,89 @@
+"""Basic network performance metrics from :class:`PcapRecord` streams."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, List
+import numpy as np
+
+from ..parser import PcapRecord
+
+
+class PerformanceAnalyzer:
+    """Track TCP handshake RTT and retransmission counts."""
+
+    def __init__(self) -> None:
+        # Keyed by a stable flow identifier string
+        self.tcp_syn_timestamps: defaultdict[str, Dict[str, float | int | None]] = defaultdict(
+            lambda: {"client_syn_ts": None, "client_seq": None}
+        )
+        self.rtt_samples_ms: List[float] = []
+        self.tcp_total_packets: int = 0
+        self.tcp_retransmissions: int = 0
+        # Placeholder for potential QUIC tracking
+        # self.quic_initial_packets: Dict[str, float] = {}
+
+    def add_packet(self, record: PcapRecord, flow_id_str: str, is_client_packet: bool) -> None:
+        """Add a packet to the analyzer.
+
+        Parameters
+        ----------
+        record:
+            Parsed packet record.
+        flow_id_str:
+            Unique identifier for the flow from the client perspective.
+        is_client_packet:
+            ``True`` if the packet direction is client -> server.
+        """
+        if record.protocol and record.protocol.upper() == "TCP":
+            self.tcp_total_packets += 1
+            if record.tcp_analysis_retransmission_flags:
+                self.tcp_retransmissions += 1
+
+            if is_client_packet and record.tcp_flags_syn and not record.tcp_flags_ack:
+                entry = self.tcp_syn_timestamps[flow_id_str]
+                entry["client_syn_ts"] = record.timestamp
+                entry["client_seq"] = record.tcp_sequence_number
+
+            if (
+                not is_client_packet
+                and record.tcp_flags_syn
+                and record.tcp_flags_ack
+            ):
+                entry = self.tcp_syn_timestamps.get(flow_id_str)
+                if (
+                    entry
+                    and entry.get("client_syn_ts") is not None
+                    and record.tcp_acknowledgment_number
+                    == (entry.get("client_seq") or 0) + 1
+                ):
+                    rtt = (record.timestamp - float(entry["client_syn_ts"])) * 1000
+                    self.rtt_samples_ms.append(rtt)
+                    self.tcp_syn_timestamps[flow_id_str] = {
+                        "client_syn_ts": None,
+                        "client_seq": None,
+                    }
+
+    def get_summary(self) -> Dict[str, object]:
+        """Return aggregated performance metrics."""
+        if self.rtt_samples_ms:
+            arr = np.array(self.rtt_samples_ms)
+            rtt_summary = {
+                "median": float(np.median(arr)),
+                "p95": float(np.percentile(arr, 95)),
+                "min": float(arr.min()),
+                "max": float(arr.max()),
+                "samples": len(self.rtt_samples_ms),
+            }
+        else:
+            rtt_summary = {"median": None, "p95": None, "min": None, "max": None, "samples": 0}
+
+        if self.tcp_total_packets:
+            retrans_percent = (self.tcp_retransmissions / self.tcp_total_packets) * 100
+        else:
+            retrans_percent = 0.0
+
+        return {
+            "tcp_rtt_ms": rtt_summary,
+            "tcp_retransmission_ratio_percent": retrans_percent,
+        }

--- a/tests/test_performance_analyzer.py
+++ b/tests/test_performance_analyzer.py
@@ -1,0 +1,62 @@
+from pcap_tool.analyze import PerformanceAnalyzer
+from pcap_tool.parser import PcapRecord
+
+
+def _flow_id(rec: PcapRecord, is_client: bool) -> str:
+    if is_client:
+        return f"{rec.source_ip}:{rec.source_port}-{rec.destination_ip}:{rec.destination_port}"
+    return f"{rec.destination_ip}:{rec.destination_port}-{rec.source_ip}:{rec.source_port}"
+
+
+def test_tcp_rtt_basic():
+    analyzer = PerformanceAnalyzer()
+
+    syn = PcapRecord(
+        frame_number=1,
+        timestamp=1.0,
+        source_ip="1.1.1.1",
+        destination_ip="2.2.2.2",
+        source_port=1234,
+        destination_port=80,
+        protocol="TCP",
+        tcp_flags_syn=True,
+        tcp_flags_ack=False,
+        tcp_sequence_number=100,
+    )
+    sa = PcapRecord(
+        frame_number=2,
+        timestamp=1.2,
+        source_ip="2.2.2.2",
+        destination_ip="1.1.1.1",
+        source_port=80,
+        destination_port=1234,
+        protocol="TCP",
+        tcp_flags_syn=True,
+        tcp_flags_ack=True,
+        tcp_sequence_number=200,
+        tcp_acknowledgment_number=101,
+    )
+
+    analyzer.add_packet(syn, _flow_id(syn, True), True)
+    analyzer.add_packet(sa, _flow_id(sa, False), False)
+
+    summary = analyzer.get_summary()
+    rtt = summary["tcp_rtt_ms"]
+    assert rtt["samples"] == 1
+    assert 199 <= rtt["median"] <= 201
+    assert summary["tcp_retransmission_ratio_percent"] == 0.0
+
+
+def test_tcp_retransmission_ratio():
+    analyzer = PerformanceAnalyzer()
+    for i in range(4):
+        rec = PcapRecord(
+            frame_number=i + 1,
+            timestamp=float(i),
+            protocol="TCP",
+            tcp_analysis_retransmission_flags=["retransmission"] if i == 2 else [],
+        )
+        analyzer.add_packet(rec, "f", True)
+
+    summary = analyzer.get_summary()
+    assert summary["tcp_retransmission_ratio_percent"] == 25.0


### PR DESCRIPTION
## Summary
- implement `PerformanceAnalyzer` with RTT and retransmission tracking
- expose analyzer from package
- add tests for RTT calculation and retransmission ratio

## Testing
- `flake8 src/ tests/`
- `pytest -q`