### PR TITLE
Add TimelineBuilder metrics utility

### DIFF
--- a/src/pcap_tool/metrics/timeline_builder.py
+++ b/src/pcap_tool/metrics/timeline_builder.py
@@ -1,0 +1,42 @@
+"""Timeline metrics utilities."""
+
+from collections import defaultdict
+from statistics import mean, pstdev
+from typing import DefaultDict, List
+
+from ..parser import PcapRecord
+
+
+class TimelineBuilder:
+    """Aggregate per-second packet and byte counts."""
+
+    def __init__(self) -> None:
+        self.bytes_per_second: DefaultDict[int, int] = defaultdict(int)
+        self.packets_per_second: DefaultDict[int, int] = defaultdict(int)
+
+    def add_packet(self, record: PcapRecord) -> None:
+        """Add a packet record to the timeline."""
+        sec_bin = int(record.timestamp)
+        self.bytes_per_second[sec_bin] += record.packet_length or 0
+        self.packets_per_second[sec_bin] += 1
+
+    def get_timeline_data(self) -> tuple[list[int], list[int], list[int]]:
+        """Return sorted time bins and corresponding byte/packet counts."""
+        bins = set(self.bytes_per_second.keys()) | set(self.packets_per_second.keys())
+        sorted_bins = sorted(bins)
+        bytes_list = [self.bytes_per_second.get(b, 0) for b in sorted_bins]
+        packets_list = [self.packets_per_second.get(b, 0) for b in sorted_bins]
+        return sorted_bins, bytes_list, packets_list
+
+    def find_spikes(self, values: List[int], sigma: float = 3.0) -> List[int]:
+        """Return indices where ``value`` is greater than ``mean + sigma * std``."""
+        if not values:
+            return []
+        if len(set(values)) <= 1:
+            return []
+        avg = mean(values)
+        std_dev = pstdev(values)
+        if std_dev == 0:
+            return []
+        threshold = avg + sigma * std_dev
+        return [i for i, v in enumerate(values) if v > threshold]

--- a/tests/test_timeline_builder.py
+++ b/tests/test_timeline_builder.py
@@ -1,0 +1,27 @@
+from pcap_tool.metrics.timeline_builder import TimelineBuilder
+from pcap_tool.parser import PcapRecord
+
+
+def test_timeline_builder_basic():
+    tb = TimelineBuilder()
+    records = [
+        PcapRecord(frame_number=1, timestamp=1.2, packet_length=100),
+        PcapRecord(frame_number=2, timestamp=1.8, packet_length=200),
+        PcapRecord(frame_number=3, timestamp=2.4, packet_length=50),
+    ]
+    for r in records:
+        tb.add_packet(r)
+
+    bins, bytes_list, pkts_list = tb.get_timeline_data()
+    assert bins == [1, 2]
+    assert bytes_list == [300, 50]
+    assert pkts_list == [2, 1]
+
+
+def test_timeline_builder_find_spikes():
+    tb = TimelineBuilder()
+    values = [10, 12, 11, 100, 9]
+    spikes = tb.find_spikes(values, sigma=1.0)
+    assert spikes == [3]
+    assert tb.find_spikes([5, 5, 5]) == []
+    assert tb.find_spikes([]) == []


### PR DESCRIPTION
## Summary
- implement `TimelineBuilder` in `metrics` package
- support adding packets and computing timeline data
- detect spikes using sigma-based thresholding
- add unit tests for new class

## Testing
- `flake8 src/ tests/`
- `pytest -q`