### PR TITLE
Add flow error summarization utilities

### DIFF
--- a/src/heuristics/rules.yaml
+++ b/src/heuristics/rules.yaml
@@ -6,6 +6,8 @@ target_column_map:
   traffic_type_rules: "traffic_type_guess"         # To make a guess about the type of traffic.
   security_observation_rules: "security_observation" # To flag potential security issues.
   zscaler_context_rules: "zscaler_specific_finding" # For Zscaler specific observations
+  flow_error_type_rules: "flow_error_type"           # High level error category
+  flow_error_details_rules: "flow_error_details"     # Human friendly error notes
 
 # 2. Define default values for these new columns.
 default_values:
@@ -13,6 +15,8 @@ default_values:
   traffic_type_guess: "Unknown"
   security_observation: "None"
   zscaler_specific_finding: "N/A"
+  flow_error_type: null
+  flow_error_details: null
 
 # 3. Define the rule sets. The keys here MUST match the keys in target_column_map.
 
@@ -298,3 +302,53 @@ zscaler_context_rules:
       - {field: "is_zscaler_ip", operator: "equals", value: true}
       - {field: "is_zpa_synthetic_ip", operator: "equals", value: false} # Avoid double-tagging
     stop_processing: false
+
+# ==============================================================================
+# Rule set for error tagging columns
+# ==============================================================================
+flow_error_type_rules:
+  - name: "TCP Reset"
+    output_value: "TCP_RESET"
+    conditions:
+      - {field: "protocol", operator: "equals", value: "TCP"}
+      - {field: "tcp_flags_rst", operator: "equals", value: true}
+    stop_processing: true
+
+  - name: "TLS Fatal Alert"
+    output_value_format: "TLS_FATAL_{tls_alert_message_description}"
+    conditions:
+      - {field: "tls_alert_level", operator: "equals", value: "fatal"}
+      - {field: "tls_alert_message_description", operator: "exists"}
+    stop_processing: true
+
+  - name: "ICMP Host Unreachable"
+    output_value: "ICMP_DEST_UNREACHABLE_HOST"
+    conditions:
+      - {field: "protocol", operator: "in", value: ["ICMP", "ICMPv6"]}
+      - {field: "icmp_type", operator: "equals", value: 3}
+      - {field: "icmp_code", operator: "equals", value: 1}
+    stop_processing: true
+
+flow_error_details_rules:
+  - name: "RST Source"
+    output_value_format: "Source: {source_ip}"
+    conditions:
+      - {field: "protocol", operator: "equals", value: "TCP"}
+      - {field: "tcp_flags_rst", operator: "equals", value: true}
+    stop_processing: true
+
+  - name: "TLS Alert Description"
+    output_value_format: "{tls_alert_message_description}"
+    conditions:
+      - {field: "tls_alert_level", operator: "equals", value: "fatal"}
+      - {field: "tls_alert_message_description", operator: "exists"}
+    stop_processing: true
+
+  - name: "ICMP Unreachable Source"
+    output_value_format: "Source: {source_ip}"
+    conditions:
+      - {field: "protocol", operator: "in", value: ["ICMP", "ICMPv6"]}
+      - {field: "icmp_type", operator: "equals", value: 3}
+      - {field: "icmp_code", operator: "equals", value: 1}
+    stop_processing: true
+

--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -10,7 +10,7 @@ from .pdf_report import generate_pdf_report
 from .summary import generate_summary_df, export_summary_excel
 from .metrics.stats_collector import StatsCollector
 from .enrichment import Enricher
-from .analyze import PerformanceAnalyzer
+from .analyze import PerformanceAnalyzer, ErrorSummarizer
 
 
 __all__ = [
@@ -25,4 +25,5 @@ __all__ = [
     "StatsCollector",
     "Enricher",
     "PerformanceAnalyzer",
+    "ErrorSummarizer",
 ]

--- a/src/pcap_tool/analyze/__init__.py
+++ b/src/pcap_tool/analyze/__init__.py
@@ -1,2 +1,4 @@
 from .performance_analyzer import PerformanceAnalyzer
-__all__ = ["PerformanceAnalyzer"]
+from .error_summarizer import ErrorSummarizer
+
+__all__ = ["PerformanceAnalyzer", "ErrorSummarizer"]

--- a/src/pcap_tool/analyze/error_summarizer.py
+++ b/src/pcap_tool/analyze/error_summarizer.py
@@ -1,0 +1,49 @@
+"""Utilities to summarize error indicators on flows."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+import pandas as pd
+
+
+class ErrorSummarizer:
+    """Aggregate flow error tags from :class:`HeuristicEngine`."""
+
+    def summarize_errors(self, tagged_flow_df: pd.DataFrame) -> Dict[str, Dict]:
+        """Return counts and sample flow IDs for each error type."""
+        if tagged_flow_df.empty or "flow_error_type" not in tagged_flow_df.columns:
+            return {}
+
+        df = tagged_flow_df.dropna(subset=["flow_error_type"]).copy()
+        result: Dict[str, Dict] = {}
+        for err_type, type_group in df.groupby("flow_error_type"):
+            err_type_str = str(err_type)
+            if "flow_error_details" in type_group.columns:
+                details_dict: Dict[str, Dict[str, object]] = {}
+                for detail, detail_group in type_group.groupby("flow_error_details"):
+                    detail_key = str(detail) if pd.notna(detail) else "other"
+                    sample_ids: List[str] = (
+                        detail_group.get("flow_id")
+                        .dropna()
+                        .astype(str)
+                        .unique()
+                        .tolist()[:3]
+                    )
+                    details_dict[detail_key] = {
+                        "count": int(len(detail_group)),
+                        "sample_flow_ids": sample_ids,
+                    }
+                result[err_type_str] = details_dict
+            else:
+                sample_ids = (
+                    type_group.get("flow_id")
+                    .dropna()
+                    .astype(str)
+                    .unique()
+                    .tolist()[:3]
+                )
+                result[err_type_str] = {
+                    "count": int(len(type_group)),
+                    "sample_flow_ids": sample_ids,
+                }
+        return result

--- a/tests/test_error_summarizer.py
+++ b/tests/test_error_summarizer.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+from pcap_tool.analyze.error_summarizer import ErrorSummarizer
+
+
+def test_summarize_errors_basic():
+    df = pd.DataFrame(
+        {
+            "flow_id": ["f1", "f2", "f3", "f4"],
+            "flow_error_type": [
+                "TCP_RESET",
+                "TCP_RESET",
+                "TLS_FATAL_HANDSHAKE_FAILURE",
+                "ICMP_DEST_UNREACHABLE_HOST",
+            ],
+            "flow_error_details": [
+                "src1",
+                "src2",
+                "handshake_failure",
+                "host_unreachable",
+            ],
+        }
+    )
+
+    result = ErrorSummarizer().summarize_errors(df)
+    assert result["TCP_RESET"]["src1"]["count"] == 1
+    assert "f1" in result["TCP_RESET"]["src1"]["sample_flow_ids"]
+    assert result["TLS_FATAL_HANDSHAKE_FAILURE"]["handshake_failure"]["count"] == 1
+    assert result["ICMP_DEST_UNREACHABLE_HOST"]["host_unreachable"]["count"] == 1


### PR DESCRIPTION
## Summary
- extend heuristic rules with flow error tagging columns and sample rules
- add `ErrorSummarizer` for counting and sampling error-tagged flows
- expose new summarizer via package `__init__`
- test the summarizer

## Testing
- `flake8 src/ tests/`
- `pytest -q`