### PR TITLE
Improve PDF report generation

### DIFF
--- a/src/pcap_tool/chart_generator.py
+++ b/src/pcap_tool/chart_generator.py
@@ -1,0 +1,43 @@
+"""Simple chart generation helpers for PDF reports."""
+
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Dict
+
+
+def protocol_pie_chart(protocol_counts: Dict[str, int]) -> bytes:
+    """Return a pie chart image for protocol distribution."""
+    if not protocol_counts:
+        return b""
+    try:
+        import matplotlib.pyplot as plt
+    except Exception:  # pragma: no cover - optional dependency
+        return b""
+    labels = list(protocol_counts.keys())
+    sizes = list(protocol_counts.values())
+    fig, ax = plt.subplots(figsize=(2, 2))
+    ax.pie(sizes, labels=labels, autopct="%1.1f%%")
+    buf = BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    return buf.getvalue()
+
+
+def top_ports_bar_chart(port_counts: Dict[str, int]) -> bytes:
+    """Return a bar chart image for top TCP/UDP ports."""
+    if not port_counts:
+        return b""
+    try:
+        import matplotlib.pyplot as plt
+    except Exception:  # pragma: no cover - optional dependency
+        return b""
+    labels = list(port_counts.keys())
+    values = list(port_counts.values())
+    fig, ax = plt.subplots(figsize=(3, 2))
+    ax.bar(labels, values)
+    ax.set_xticklabels(labels, rotation=45, ha="right")
+    buf = BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    return buf.getvalue()

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,13 +1,23 @@
-import pandas as pd
 import pytest
 
 from pcap_tool.pdf_report import generate_pdf_report
 
 
 def test_generate_pdf_report_basic():
-    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    metrics = {
+        "capture_info": {"filename": "test.pcap"},
+        "protocols": {"tcp": 1, "udp": 1},
+        "top_ports": {"tcp_80": 1},
+        "top_talkers_by_bytes": [
+            {"src_ip": "1.1.1.1", "dest_ip": "2.2.2.2", "bytes_total": 1000}
+        ],
+        "performance_metrics": {"median_rtt_ms": 10, "retrans_pct": 0.0},
+        "error_summary": {},
+        "security_findings": {},
+        "timeline_data": [],
+    }
     try:
-        pdf_bytes = generate_pdf_report(df)
+        pdf_bytes = generate_pdf_report(metrics)
     except ImportError:
         pytest.skip("ReportLab not installed")
     assert isinstance(pdf_bytes, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- extend `generate_pdf_report` to accept metrics dict and optional flows
- create small chart generation helper using matplotlib
- update PDF report to output many metrics including optional charts
- adjust PDF smoke test for new interface

## Testing
- `flake8 src/ tests/`
- `pytest -q`