### PR TITLE
Add GPT-based metrics summarizer

### DIFF
--- a/src/llm_summarizer.py
+++ b/src/llm_summarizer.py
@@ -1,0 +1,81 @@
+"""LLM-based summarizer for metrics."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from typing import Optional
+from pathlib import Path
+
+import openai
+
+logger = logging.getLogger(__name__)
+
+
+class LLMSummarizerError(Exception):
+    """Raised when LLM summarization fails."""
+
+
+class LLMSummarizer:
+    """Generate plain-English summaries of metrics via GPT."""
+
+    def __init__(self, client: Optional[openai.Client] = None, model: str = "gpt-4o") -> None:
+        """Initialize the summarizer with an optional OpenAI client."""
+        if client is None:
+            api_key = os.environ.get("OPENAI_API_KEY")
+            client = openai.Client(api_key=api_key)
+        self.client = client
+        self.model = model
+
+    def generate_text_summary(
+        self,
+        metrics_json: dict,
+        *,
+        temperature: float = 0.3,
+        max_tokens: int = 800,
+    ) -> str:
+        """Return a plain-English summary of ``metrics_json`` using GPT."""
+        payload = json.dumps(metrics_json, indent=2)
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "You are a senior network-operations analyst. "
+                    "Return a concise plain-English summary of the supplied metrics. "
+                    "Highlight key patterns, potential issues, and actionable insights. "
+                    "Use short paragraphs and bullet lists where helpful. "
+                    "Do not invent metrics that are not present."
+                ),
+            },
+            {"role": "user", "content": f"Here is the metrics payload:\n```json\n{payload}\n```"},
+        ]
+
+        for attempt in range(3):
+            try:
+                response = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    timeout=30,
+                )
+                logger.debug(
+                    "LLM summary request id=%s tokens=%s",
+                    response.id,
+                    response.usage.total_tokens,
+                )
+                return response.choices[0].message.content.strip()
+            except (openai.RateLimitError, TimeoutError, openai.APIError) as exc:
+                if attempt == 2:
+                    raise LLMSummarizerError(str(exc)) from exc
+                time.sleep(2 ** attempt)
+
+        raise LLMSummarizerError("Failed to generate summary")
+
+
+if __name__ == "__main__":
+
+    sample = json.loads(Path("examples/metrics_sample.json").read_text())
+    print(LLMSummarizer().generate_text_summary(sample))

--- a/tests/test_llm_summarizer.py
+++ b/tests/test_llm_summarizer.py
@@ -1,0 +1,23 @@
+import openai
+from unittest.mock import Mock, patch
+
+from llm_summarizer import LLMSummarizer
+
+
+def test_generate_text_summary_basic():
+    metrics = {"foo": "bar"}
+    fake_response = Mock()
+    fake_response.id = "abc123"
+    fake_usage = Mock(total_tokens=5)
+    fake_response.usage = fake_usage
+    fake_response.choices = [Mock(message=Mock(content="the summary"))]
+
+    client = openai.Client(api_key="test")
+    summarizer = LLMSummarizer(client=client)
+
+    with patch.object(client.chat.completions, "create", return_value=fake_response) as mock_create:
+        result = summarizer.generate_text_summary(metrics)
+
+    called_messages = mock_create.call_args.kwargs["messages"]
+    assert "\"foo\": \"bar\"" in called_messages[1]["content"]
+    assert result == "the summary"


### PR DESCRIPTION
## Summary
- implement `LLMSummarizer` for GPT-4o summaries
- log request id and token usage
- handle OpenAI API errors with retry
- add unit tests for summarizer

## Testing
- `flake8 src/ tests/`
- `pytest -q`