### PR TITLE
Handle None integer fields before type casting

### DIFF
--- a/src/pcap_tool/analyze/performance_analyzer.py
+++ b/src/pcap_tool/analyze/performance_analyzer.py
@@ -43,7 +43,7 @@ class PerformanceAnalyzer:
             if is_client_packet and record.tcp_flags_syn and not record.tcp_flags_ack:
                 entry = self.tcp_syn_timestamps[flow_id_str]
                 entry["client_syn_ts"] = record.timestamp
-                entry["client_seq"] = record.tcp_sequence_number
+                entry["client_seq"] = int(record.tcp_sequence_number or 0)
 
             if (
                 not is_client_packet
@@ -54,7 +54,7 @@ class PerformanceAnalyzer:
                 if (
                     entry
                     and entry.get("client_syn_ts") is not None
-                    and record.tcp_acknowledgment_number
+                    and int(record.tcp_acknowledgment_number or -1)
                     == (entry.get("client_seq") or 0) + 1
                 ):
                     rtt = (record.timestamp - float(entry["client_syn_ts"])) * 1000

--- a/src/pcap_tool/metrics/flow_table.py
+++ b/src/pcap_tool/metrics/flow_table.py
@@ -36,23 +36,20 @@ class FlowTable:
         self.flows: Dict[Tuple[str, str, int, int, str], Flow] = {}
 
     def _get_key(self, rec: PcapRecord, is_src_client: bool) -> Tuple[str, str, int, int, str]:
+        src_ip = rec.source_ip or ""
+        dest_ip = rec.destination_ip or ""
+        src_port = int(rec.source_port or 0)
+        dest_port = int(rec.destination_port or 0)
+        proto = rec.protocol or ""
         if is_src_client:
-            return rec.source_ip or "", rec.destination_ip or "", int(rec.source_port or 0), int(
-                rec.destination_port or 0
-            ), rec.protocol or ""
-        return (
-            rec.destination_ip or "",
-            rec.source_ip or "",
-            int(rec.destination_port or 0),
-            int(rec.source_port or 0),
-            rec.protocol or "",
-        )
+            return src_ip, dest_ip, src_port, dest_port, proto
+        return dest_ip, src_ip, dest_port, src_port, proto
 
     def add_packet(self, record: PcapRecord, is_src_client: bool) -> None:
         """Update flow counters from ``record``."""
         key = self._get_key(record, is_src_client)
         flow = self.flows.get(key)
-        ts = float(record.timestamp)
+        ts = float(record.timestamp or 0.0)
         length = int(record.packet_length or 0)
         if flow is None:
             flow = Flow(

--- a/src/pcap_tool/metrics/stats_collector.py
+++ b/src/pcap_tool/metrics/stats_collector.py
@@ -20,9 +20,9 @@ class StatsCollector:
             key = str(proto).lower()
             self.protocol_counts[key] += 1
 
-            dest_port = record.destination_port
-            if dest_port is not None and dest_port == dest_port and key in {"tcp", "udp"}:
-                port_key = f"{key}_{int(dest_port)}"
+            if key in {"tcp", "udp"}:
+                port_val = int(record.destination_port or 0)
+                port_key = f"{key}_{port_val}"
                 self.port_counts[port_key] += 1
 
     def summary(self) -> Dict[str, Dict[str, int]]:

--- a/src/pcap_tool/metrics/timeline_builder.py
+++ b/src/pcap_tool/metrics/timeline_builder.py
@@ -16,7 +16,7 @@ class TimelineBuilder:
 
     def add_packet(self, record: PcapRecord) -> None:
         """Add a packet record to the timeline."""
-        sec_bin = int(record.timestamp)
+        sec_bin = int(record.timestamp or 0)
         self.bytes_per_second[sec_bin] += record.packet_length or 0
         self.packets_per_second[sec_bin] += 1
 


### PR DESCRIPTION
## Summary
- guard StatsCollector port count against missing destination_port
- ensure FlowTable handles None timestamps and ports
- sanitize sequence and ack numbers in PerformanceAnalyzer
- default missing timestamp in TimelineBuilder

## Testing
- `flake8 src/ tests/`
- `pytest -q`
