### PR TITLE
Fix metrics builder dropna error

### DIFF
--- a/src/pcap_tool/analyze/error_summarizer.py
+++ b/src/pcap_tool/analyze/error_summarizer.py
@@ -22,9 +22,11 @@ class ErrorSummarizer:
                 details_dict: Dict[str, Dict[str, object]] = {}
                 for detail, detail_group in type_group.groupby("flow_error_details"):
                     detail_key = str(detail) if pd.notna(detail) else "other"
+                    flow_series = detail_group.get(
+                        "flow_id", pd.Series(dtype=object)
+                    )
                     sample_ids: List[str] = (
-                        detail_group.get("flow_id")
-                        .dropna()
+                        flow_series.dropna()
                         .astype(str)
                         .unique()
                         .tolist()[:3]
@@ -35,9 +37,9 @@ class ErrorSummarizer:
                     }
                 result[err_type_str] = details_dict
             else:
+                flow_series = type_group.get("flow_id", pd.Series(dtype=object))
                 sample_ids = (
-                    type_group.get("flow_id")
-                    .dropna()
+                    flow_series.dropna()
                     .astype(str)
                     .unique()
                     .tolist()[:3]

--- a/src/pcap_tool/analyze/security_auditor.py
+++ b/src/pcap_tool/analyze/security_auditor.py
@@ -56,7 +56,7 @@ class SecurityAuditor:
         unusual_connections: Dict[str, str] = {}
 
         for idx, row in tagged_flow_df.iterrows():
-            dest_ip = row.get("destination_ip")
+            dest_ip = row.get("destination_ip", row.get("dest_ip"))
             if pd.isna(dest_ip):
                 continue
             info = enriched_ips.get(str(dest_ip))

--- a/tests/test_missing_columns.py
+++ b/tests/test_missing_columns.py
@@ -1,0 +1,49 @@
+import pandas as pd
+from pcap_tool.metrics_builder import MetricsBuilder
+from pcap_tool.analyze import ErrorSummarizer, SecurityAuditor, PerformanceAnalyzer
+from pcap_tool.metrics.flow_table import FlowTable
+from pcap_tool.metrics.stats_collector import StatsCollector
+from pcap_tool.metrics.timeline_builder import TimelineBuilder
+from pcap_tool.enrichment import Enricher
+
+
+class DummyServiceGuesser:
+    def guess_service(self, *args, **kwargs):
+        return "dummy"
+
+
+class DummyHeuristic:
+    pass
+
+
+class DummyEnricher(Enricher):
+    def enrich_ips(self, ips):
+        return {ip: {} for ip in ips}
+
+
+class DummyStats(StatsCollector):
+    def summary(self):
+        return {"capture_info": {}, "protocols": {}, "top_ports": {}, "quic_vs_tls_packets": {}}
+
+
+def test_metrics_builder_with_dest_ip_only():
+    mb = MetricsBuilder(
+        DummyStats(),
+        FlowTable(),
+        DummyEnricher(),
+        DummyServiceGuesser(),
+        PerformanceAnalyzer(),
+        TimelineBuilder(),
+        ErrorSummarizer(),
+        SecurityAuditor(DummyEnricher()),
+        DummyHeuristic(),
+    )
+
+    packet_df = pd.DataFrame()
+    tagged_flow_df = pd.DataFrame({"dest_ip": ["1.2.3.4"], "protocol": ["TCP"], "dest_port": [80]})
+    metrics = mb.build_metrics(packet_df, tagged_flow_df)
+    assert metrics["service_overview"]
+def test_error_summarizer_no_flow_id():
+    df = pd.DataFrame({"flow_error_type": ["TYPE1", "TYPE1"]})
+    result = ErrorSummarizer().summarize_errors(df)
+    assert result == {"TYPE1": {"count": 2, "sample_flow_ids": []}}


### PR DESCRIPTION
## Summary
- avoid AttributeError when destination columns are absent
- guard against missing flow_id in error summarizer
- accept dest_ip in security auditor
- keep analysis robust when dest_ip/dest_port columns used
- test missing column scenarios

## Testing
- `flake8 src/ tests/`
- `pytest -q`