### PR TITLE
Fix record variable for non-IP packets

### DIFF
--- a/src/pcap_tool/heuristics/metrics.py
+++ b/src/pcap_tool/heuristics/metrics.py
@@ -48,4 +48,3 @@ def compute_tcp_rtt_stats(flow_rtt_samples: List[float]) -> Dict[str, Optional[f
         "max": float(arr.max()),
         "samples": len(flow_rtt_samples),
     }
-

--- a/src/pcap_tool/parser.py
+++ b/src/pcap_tool/parser.py
@@ -566,8 +566,7 @@ def _parse_with_pyshark(
                 else:
                     # For non-IP/non-ARP, yield basic L2 info if available
                     if packet_count > generated_records:
-
-                         yield PcapRecord(
+                        record_obj = PcapRecord(
                             frame_number=frame_number,
                             timestamp=timestamp,
                             source_mac=source_mac,
@@ -575,14 +574,14 @@ def _parse_with_pyshark(
                             packet_length=packet_length_val,
                             raw_packet_summary=raw_summary,
                             tcp_rtt_ms=None,
-
-
                             # Other fields default to None
-                         )
-                         logger.debug(f"Appending processed packet to list: {record_obj}")
-                         yield record_obj
-                         generated_records +=1
-                    continue # Skip to next packet
+                        )
+                        logger.debug(
+                            f"Appending processed packet to list: {record_obj}"
+                        )
+                        yield record_obj
+                        generated_records += 1
+                    continue  # Skip to next packet
 
                 transport_layer_obj = None
                 tcp_rtt_ms_sample = None


### PR DESCRIPTION
## Summary
- create a `record_obj` variable when handling non-IP packets
- log and yield from that variable
- trim trailing blank line in `heuristics.metrics`

## Testing
- `flake8 src/ tests/`
- `pytest -q`