### PR TITLE
Add L7 protocol inference

### DIFF
--- a/src/pcap_tool/heuristics/protocol_inference.py
+++ b/src/pcap_tool/heuristics/protocol_inference.py
@@ -1,0 +1,71 @@
+"""Utilities for inferring L7 protocols from flow metadata."""
+
+from __future__ import annotations
+
+from typing import Mapping, Any
+import pandas as pd
+
+
+# Mapping of (L4 protocol, port) -> well-known application protocol
+_WELL_KNOWN_PORTS: dict[tuple[str, int], str] = {
+    ("TCP", 20): "FTP",
+    ("TCP", 21): "FTP",
+    ("TCP", 22): "SSH",
+    ("TCP", 23): "Telnet",
+    ("TCP", 25): "SMTP",
+    ("TCP", 53): "DNS",
+    ("UDP", 53): "DNS",
+    ("TCP", 80): "HTTP",
+    ("TCP", 110): "POP3",
+    ("TCP", 143): "IMAP",
+    ("TCP", 443): "HTTPS/TLS",
+}
+
+
+def _to_int(value: Any) -> int | None:
+    """Return ``int(value)`` if possible else ``None``."""
+    if pd.isna(value):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def guess_l7_protocol(flow_data: Mapping[str, Any]) -> str:
+    """Return a best guess at the L7 protocol for ``flow_data``.
+
+    Parameters
+    ----------
+    flow_data:
+        A mapping or object behaving like a dict containing at least
+        ``protocol`` and ``dest_port`` or ``destination_port`` keys. ``src_port``
+        is consulted for QUIC detection.
+    """
+
+    protocol = str(flow_data.get("protocol", "")).upper()
+    dest_port = _to_int(
+        flow_data.get("dest_port", flow_data.get("destination_port"))
+    )
+    src_port = _to_int(
+        flow_data.get("src_port", flow_data.get("source_port"))
+    )
+
+    # --- QUIC detection on UDP/443 ---
+    if protocol == "UDP" and (dest_port == 443 or src_port == 443):
+        first_size = _to_int(
+            flow_data.get("first_flight_bytes")
+            or flow_data.get("first_flight_packet_size")
+        )
+        if first_size is not None and first_size > 1200:
+            return "QUIC"
+        return "QUIC_UDP_443"
+
+    # --- Lookup table for other well-known ports ---
+    port = dest_port if dest_port is not None else src_port
+    if port is not None:
+        guess = _WELL_KNOWN_PORTS.get((protocol, port))
+        if guess:
+            return guess
+
+    return protocol if protocol else "Unknown_L7"

--- a/src/pcap_tool/metrics/flow_table.py
+++ b/src/pcap_tool/metrics/flow_table.py
@@ -9,6 +9,7 @@ from typing import Dict, Tuple, Iterable
 
 from ..parser import PcapRecord
 from ..utils import safe_int_or_default
+from ..heuristics.protocol_inference import guess_l7_protocol
 
 
 @dataclass
@@ -100,6 +101,13 @@ class FlowTable:
                     "src_port": flow.src_port,
                     "dest_port": flow.dest_port,
                     "protocol": flow.protocol,
+                    "l7_protocol_guess": guess_l7_protocol(
+                        {
+                            "protocol": flow.protocol,
+                            "src_port": flow.src_port,
+                            "dest_port": flow.dest_port,
+                        }
+                    ),
                     "bytes_c2s": flow.bytes_c2s,
                     "bytes_s2c": flow.bytes_s2c,
                     "bytes_total": bytes_total,

--- a/tests/test_flow_table.py
+++ b/tests/test_flow_table.py
@@ -57,3 +57,4 @@ def test_flow_table_basic():
     assert row["sparkline_bytes_c2s"] == "100,150"
     assert row["sparkline_bytes_s2c"] == "200,0"
     assert len(row["sparkline_bytes_c2s"].split(",")) == 2
+    assert row["l7_protocol_guess"] == "HTTP"

--- a/tests/test_flow_table_l7.py
+++ b/tests/test_flow_table_l7.py
@@ -1,0 +1,39 @@
+from pcap_tool.metrics.flow_table import FlowTable
+from pcap_tool.parser import PcapRecord
+
+
+def _make_record(frame, ts, sport, dport, proto):
+    return PcapRecord(
+        frame_number=frame,
+        timestamp=ts,
+        source_ip="1.1.1.1",
+        destination_ip="2.2.2.2",
+        source_port=sport,
+        destination_port=dport,
+        protocol=proto,
+        packet_length=100,
+    )
+
+
+def test_l7_protocol_guess_in_summary_df():
+    ft = FlowTable()
+    packets = [
+        _make_record(1, 1.0, 1111, 80, "TCP"),
+        _make_record(2, 1.1, 1111, 80, "TCP"),
+        _make_record(3, 2.0, 2222, 53, "UDP"),
+        _make_record(4, 2.1, 2222, 53, "UDP"),
+        _make_record(5, 3.0, 3333, 443, "UDP"),
+    ]
+
+    ft.add_packet(packets[0], True)
+    ft.add_packet(packets[1], True)
+    ft.add_packet(packets[2], True)
+    ft.add_packet(packets[3], False)
+    ft.add_packet(packets[4], True)
+
+    df_bytes, _ = ft.get_summary_df()
+    assert "l7_protocol_guess" in df_bytes.columns
+    guesses = set(df_bytes["l7_protocol_guess"].tolist())
+    assert "HTTP" in guesses
+    assert "DNS" in guesses
+    assert "QUIC_UDP_443" in guesses

--- a/tests/test_protocol_inference.py
+++ b/tests/test_protocol_inference.py
@@ -1,0 +1,28 @@
+import pandas as pd
+
+from pcap_tool.heuristics.protocol_inference import guess_l7_protocol
+
+
+def test_quic_guess():
+    data = {"protocol": "UDP", "dest_port": 443}
+    assert guess_l7_protocol(data) == "QUIC_UDP_443"
+
+
+def test_quic_guess_src_port():
+    data = {"protocol": "UDP", "src_port": 443, "dest_port": 1234}
+    assert guess_l7_protocol(data) == "QUIC_UDP_443"
+
+
+def test_known_tcp_port():
+    data = {"protocol": "TCP", "dest_port": 22}
+    assert guess_l7_protocol(data) == "SSH"
+
+
+def test_unknown_fallback():
+    data = {"protocol": "TCP", "dest_port": 9999}
+    assert guess_l7_protocol(data) == "TCP"
+
+
+def test_series_input():
+    series = pd.Series({"protocol": "TCP", "dest_port": 80})
+    assert guess_l7_protocol(series) == "HTTP"


### PR DESCRIPTION
## Summary
- add `guess_l7_protocol` helper to infer application protocol
- infer L7 protocol when summarizing flows
- add tests covering flow table protocol guesses

## Testing
- `flake8 src/ tests`
- `pytest -q`
