### PR TITLE
Implement error detection heuristic

### DIFF
--- a/src/pcap_tool/heuristics/errors.py
+++ b/src/pcap_tool/heuristics/errors.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Mapping, Any
+
+
+def detect_packet_error(packet_data: Mapping[str, Any]) -> str:
+    """Return a simple classification of packet level network errors.
+
+    Parameters
+    ----------
+    packet_data:
+        Mapping with packet fields such as ``protocol``, ``icmp_type``,
+        ``icmp_code`` and ``tcp_flags_rst``.
+    """
+    protocol = str(packet_data.get("protocol") or "").upper()
+    icmp_type = packet_data.get("icmp_type")
+    icmp_code = packet_data.get("icmp_code")
+    tcp_rst = packet_data.get("tcp_flags_rst")
+
+    try:
+        icmp_type_int = int(icmp_type) if icmp_type is not None else None
+    except (TypeError, ValueError):
+        icmp_type_int = None
+    try:
+        icmp_code_int = int(icmp_code) if icmp_code is not None else None
+    except (TypeError, ValueError):
+        icmp_code_int = None
+
+    if protocol == "ICMP":
+        if icmp_type_int == 3 and icmp_code_int in {0, 1, 2, 3}:
+            return "ICMP_Destination_Unreachable"
+        if icmp_type_int == 11:
+            return "ICMP_Time_Exceeded"
+
+    if protocol == "TCP" and bool(tcp_rst):
+        return "TCP_RST_Received"
+
+    return "no_error_detected"

--- a/tests/test_error_detector.py
+++ b/tests/test_error_detector.py
@@ -1,0 +1,40 @@
+import pytest
+from pathlib import Path
+from scapy.all import Ether, IP, TCP, ICMP, PcapWriter
+
+from pcap_tool.parser import parse_pcap_to_df
+
+
+def _create_pcap(packets, tmp_path: Path, name: str) -> Path:
+    p = tmp_path / name
+    with PcapWriter(str(p), sync=True) as w:
+        for pkt in packets:
+            w.write(pkt)
+    return p
+
+
+@pytest.fixture
+def error_packets_pcap(tmp_path: Path) -> Path:
+    base_time = 1.0
+    pkt1 = Ether()/IP(src="1.1.1.1", dst="2.2.2.2")/ICMP(type=3, code=0)
+    pkt1.time = base_time
+    pkt2 = Ether()/IP(src="1.1.1.1", dst="2.2.2.2")/ICMP(type=3, code=3)
+    pkt2.time = base_time + 1
+    pkt3 = Ether()/IP(src="1.1.1.1", dst="2.2.2.2")/ICMP(type=11, code=0)
+    pkt3.time = base_time + 2
+    pkt4 = Ether()/IP(src="3.3.3.3", dst="4.4.4.4")/TCP(sport=1234, dport=80, flags="R")
+    pkt4.time = base_time + 3
+    pkt5 = Ether()/IP(src="5.5.5.5", dst="6.6.6.6")/TCP(sport=5555, dport=80, flags="A")
+    pkt5.time = base_time + 4
+    packets = [pkt1, pkt2, pkt3, pkt4, pkt5]
+    return _create_pcap(packets, tmp_path, "errors.pcap")
+
+
+def test_detect_packet_error_dataframe(error_packets_pcap: Path):
+    df = parse_pcap_to_df(str(error_packets_pcap), workers=0)
+    assert "packet_error_reason" in df.columns
+    assert df.iloc[0]["packet_error_reason"] == "ICMP_Destination_Unreachable"
+    assert df.iloc[1]["packet_error_reason"] == "ICMP_Destination_Unreachable"
+    assert df.iloc[2]["packet_error_reason"] == "ICMP_Time_Exceeded"
+    assert df.iloc[3]["packet_error_reason"] == "TCP_RST_Received"
+    assert df.iloc[4]["packet_error_reason"] == "no_error_detected"


### PR DESCRIPTION
## Summary
- add network error detector heuristic
- detect packet errors when parsing pcaps
- parse tcp RST flag correctly if pyshark provides `flags_reset`
- test packet error detection logic

## Testing
- `flake8 src/ tests/`
- `pytest -q`