### PR TITLE
Implement resilient flow outcome rules

### DIFF
--- a/src/heuristics/rules.yaml
+++ b/src/heuristics/rules.yaml
@@ -23,6 +23,7 @@ default_values:
   security_flag_plaintext_http: false
   security_flag_outdated_tls_version: null
   security_flag_self_signed_cert: false
+  flow_outcome: "Analyzed"
 
 # 3. Define the rule sets. The keys here MUST match the keys in target_column_map.
 
@@ -393,4 +394,27 @@ security_flag_self_signed_cert_rules:
     conditions:
       - {field: "tls_cert_is_self_signed", operator: "equals", value: true}
     stop_processing: false
+
+# ==============================================================================
+# Rule set for detailed flow outcome tagging
+# ==============================================================================
+flow_outcome_rules:
+  - name: blocked_dns_nxdomain
+    value: "Blocked_DNS_NXDOMAIN"
+    conditions:
+      - field: dns_rcode_name
+        operator: equals
+        value: "NXDOMAIN"
+  - name: reset_by_server_after_tls_handshake
+    value: "Degraded_Reset_After_TLS"
+    conditions:
+      - field: packet_error_reason
+        operator: contains
+        value: "TCP_RST_Received"
+      - field: tcp_initiator
+        operator: equals
+        value: "client"
+      - field: tls_handshake_successful
+        operator: equals
+        value: true
 

--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -11,7 +11,6 @@ from .pdf_report import generate_pdf_report
 from .summary import generate_summary_df, export_summary_excel
 from .utils import export_to_csv
 from .metrics.stats_collector import StatsCollector
-from .enrichment import Enricher
 from .analyze import PerformanceAnalyzer, ErrorSummarizer
 
 
@@ -27,7 +26,6 @@ __all__ = [
     "export_summary_excel",
     "export_to_csv",
     "StatsCollector",
-    "Enricher",
     "PerformanceAnalyzer",
     "ErrorSummarizer",
 ]

--- a/tests/test_enrichment.py
+++ b/tests/test_enrichment.py
@@ -52,8 +52,10 @@ sys.modules.setdefault("geoip2", geoip2_mod)
 sys.modules.setdefault("geoip2.database", database_mod)
 sys.modules.setdefault("geoip2.errors", errors_mod)
 
+import importlib
 import geoip2.database
 import pcap_tool.enrichment as enrichment_mod
+enrichment_mod = importlib.reload(enrichment_mod)
 from pcap_tool.enrichment import Enricher
 
 


### PR DESCRIPTION
## Summary
- add robust error handling for YAML rule loading and per-flow rule processing
- support new `flow_outcome_rules` and default outcome
- skip importing Enricher during package init to avoid geoip dependency
- test engine flow outcome tagging and bad YAML cases
- ensure enrichment tests reload module for stubbed geoip reader

## Testing
- `flake8 src/ tests/`
- `pytest -q`