### PR TITLE
Introduce pcap_tool.models module

### DIFF
--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -3,10 +3,9 @@ from .parser import (
     parse_pcap,
     parse_pcap_to_df,
     iter_parsed_frames,
-    PcapRecord,
-    ParsedHandle,
     validate_pcap_file,
 )
+from .models import PcapRecord, ParsedHandle
 from .pdf_report import generate_pdf_report
 from .summary import generate_summary_df, export_summary_excel
 from .utils import export_to_csv

--- a/src/pcap_tool/analyze/performance_analyzer.py
+++ b/src/pcap_tool/analyze/performance_analyzer.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 from typing import Dict, List
 import numpy as np
 
-from ..parser import PcapRecord
+from ..models import PcapRecord
 from ..utils import safe_int_or_default
 
 

--- a/src/pcap_tool/heuristics/metrics.py
+++ b/src/pcap_tool/heuristics/metrics.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import Iterable, Mapping, Dict, Any
 
-from ..parser import PcapRecord
+from ..models import PcapRecord
 
 
 def count_tls_versions(records: Iterable[Any]) -> Dict[str, int]:

--- a/src/pcap_tool/metrics/flow_table.py
+++ b/src/pcap_tool/metrics/flow_table.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, Tuple, Iterable
 
-from ..parser import PcapRecord
+from ..models import PcapRecord
 from ..utils import safe_int_or_default
 from ..heuristics.protocol_inference import guess_l7_protocol
 

--- a/src/pcap_tool/metrics/stats_collector.py
+++ b/src/pcap_tool/metrics/stats_collector.py
@@ -3,7 +3,7 @@
 from collections import Counter
 from typing import Dict
 
-from ..parser import PcapRecord
+from ..models import PcapRecord
 
 
 class StatsCollector:

--- a/src/pcap_tool/metrics/timeline_builder.py
+++ b/src/pcap_tool/metrics/timeline_builder.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 from statistics import mean, pstdev
 from typing import DefaultDict, List
 
-from ..parser import PcapRecord
+from ..models import PcapRecord
 
 
 class TimelineBuilder:

--- a/src/pcap_tool/models.py
+++ b/src/pcap_tool/models.py
@@ -1,0 +1,227 @@
+"""Core data structures for parsed packet records."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, List, Optional
+import pandas as pd
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    """Safely convert numbers that may contain commas to ``int``."""
+
+    try:
+        return int(str(value).replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass
+class PcapRecord:
+    frame_number: int
+    timestamp: float
+    source_ip: Optional[str] = None
+    destination_ip: Optional[str] = None
+    source_port: Optional[int] = None
+    destination_port: Optional[int] = None
+    protocol: Optional[str] = None
+    sni: Optional[str] = None
+    raw_packet_summary: Optional[str] = None
+    source_mac: Optional[str] = None
+    destination_mac: Optional[str] = None
+    protocol_l3: Optional[str] = None
+    packet_length: Optional[int] = None
+    ip_ttl: Optional[int] = None
+    ip_flags_df: Optional[bool] = None
+    ip_id: Optional[str] = None
+    dscp_value: Optional[int] = None
+    tcp_flags_syn: Optional[bool] = None
+    tcp_flags_ack: Optional[bool] = None
+    tcp_flags_fin: Optional[bool] = None
+    tcp_flags_rst: Optional[bool] = None
+    tcp_flags_psh: Optional[bool] = None
+    tcp_flags_urg: Optional[bool] = None
+    tcp_flags_ece: Optional[bool] = None
+    tcp_flags_cwr: Optional[bool] = None
+    tcp_sequence_number: Optional[int] = None
+    tcp_acknowledgment_number: Optional[int] = None
+    tcp_window_size: Optional[int] = None
+    tcp_options_mss: Optional[int] = None
+    tcp_options_sack_permitted: Optional[bool] = None
+    tcp_options_window_scale: Optional[int] = None
+    tcp_stream_index: Optional[int] = None
+    is_src_client: Optional[bool] = None
+    is_source_client: Optional[bool] = None
+    tcp_analysis_retransmission_flags: List[str] = field(default_factory=list)
+    tcp_analysis_duplicate_ack_flags: List[str] = field(default_factory=list)
+    tcp_analysis_out_of_order_flags: List[str] = field(default_factory=list)
+    tcp_analysis_window_flags: List[str] = field(default_factory=list)
+    dup_ack_num: Optional[int] = None
+    adv_window: Optional[int] = None
+    tcp_rtt_ms: Optional[float] = None
+    tls_handshake_type: Optional[str] = None
+    tls_handshake_version: Optional[str] = None
+    tls_record_version: Optional[str] = None
+    tls_cipher_suites_offered: Optional[List[str]] = None
+    tls_cipher_suite_selected: Optional[str] = None
+    tls_alert_message_description: Optional[str] = None
+    tls_alert_level: Optional[str] = None
+    tls_effective_version: Optional[str] = None
+    # ── TLS certificate metadata ─────────────────────────────────────────
+    tls_cert_subject_cn: Optional[str] = None
+    tls_cert_san_dns: Optional[List[str]] = None  # list of DNS SANs
+    tls_cert_san_ip: Optional[List[str]] = None   # list of IP SANs
+    tls_cert_issuer_cn: Optional[str] = None
+    tls_cert_serial_number: Optional[str] = None
+    tls_cert_not_before: Optional[datetime] = None
+    tls_cert_not_after: Optional[datetime] = None
+    tls_cert_sig_alg: Optional[str] = None
+    tls_cert_key_length: Optional[int] = None
+    tls_cert_is_self_signed: Optional[bool] = None
+    dns_query_name: Optional[str] = None
+    dns_query_type: Optional[str] = None
+    dns_response_code: Optional[str] = None
+    dns_response_addresses: Optional[List[str]] = None
+    dns_response_cname_target: Optional[str] = None
+    http_request_method: Optional[str] = None
+    http_request_uri: Optional[str] = None
+    http_request_host_header: Optional[str] = None
+    http_response_code: Optional[int] = None
+    http_response_location_header: Optional[str] = None
+    http_x_forwarded_for_header: Optional[str] = None
+    icmp_type: Optional[int] = None
+    icmp_code: Optional[int] = None
+    icmp_fragmentation_needed_original_mtu: Optional[int] = None
+    arp_opcode: Optional[int] = None
+    arp_sender_mac: Optional[str] = None
+    arp_sender_ip: Optional[str] = None
+    arp_target_mac: Optional[str] = None
+    arp_target_ip: Optional[str] = None
+    dhcp_message_type: Optional[str] = None
+    gre_protocol: Optional[str] = None
+    esp_spi: Optional[str] = None
+    quic_initial_packet_present: Optional[bool] = None
+    is_quic: Optional[bool] = None
+    is_zscaler_ip: Optional[bool] = None
+    is_zpa_synthetic_ip: Optional[bool] = None
+    ssl_inspection_active: Optional[bool] = None
+    zscaler_policy_block_type: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Normalize key fields for consistency."""
+
+        try:
+            self.frame_number = int(self.frame_number)
+        except (TypeError, ValueError):
+            self.frame_number = 0
+        try:
+            self.timestamp = float(self.timestamp)
+        except (TypeError, ValueError):
+            self.timestamp = 0.0
+
+        if isinstance(self.source_port, str):
+            self.source_port = _safe_int(self.source_port)
+        if isinstance(self.destination_port, str):
+            self.destination_port = _safe_int(self.destination_port)
+
+        if isinstance(self.tcp_stream_index, str):
+            self.tcp_stream_index = _safe_int(self.tcp_stream_index)
+
+    def __str__(self) -> str:
+        # ... (previous __str__ content, potentially updated for new fields) ...
+        final_chunk_info: List[str] = []
+        if self.gre_protocol:
+            final_chunk_info.append(f"GRE_Proto:{self.gre_protocol}")
+        if self.esp_spi:
+            final_chunk_info.append(f"ESP_SPI:{self.esp_spi}")
+        if self.quic_initial_packet_present is not None:
+            final_chunk_info.append(f"QUIC_Initial:{self.quic_initial_packet_present}")
+        if self.is_quic is not None:
+            final_chunk_info.append(f"IsQUIC:{self.is_quic}")
+        if self.is_zscaler_ip is not None:
+            final_chunk_info.append(f"ZscalerIP:{self.is_zscaler_ip}")
+        if self.is_zpa_synthetic_ip is not None:
+            final_chunk_info.append(f"ZPA_SynthIP:{self.is_zpa_synthetic_ip}")
+        if self.is_src_client is not None:
+            final_chunk_info.append(f"SrcIsClient:{self.is_src_client}")
+        if self.ssl_inspection_active is not None:
+            final_chunk_info.append(f"SSL_Inspect:{self.ssl_inspection_active}")
+        if self.zscaler_policy_block_type:
+            final_chunk_info.append(f"ZS_Block:{self.zscaler_policy_block_type}")
+        final_chunk_str = ", ".join(final_chunk_info)
+
+        return (
+            f"Frame: {self.frame_number}, Time: {self.timestamp:.6f}, "
+            f"IP: {self.source_ip or 'N/A'}:{self.source_port or 'N/A'} -> "
+            f"{self.destination_ip or 'N/A'}:{self.destination_port or 'N/A'}, "
+            f"L4_Proto: {self.protocol or 'N/A'}, "
+            f"Extra: [{final_chunk_str if final_chunk_str else 'N/A'}], SNI: {self.sni if self.sni else 'N/A'}"
+        )
+
+
+class ParsedHandle:
+    """Represents parsed flows stored in memory or on disk."""
+
+    def __init__(self, backend: str, location: Any):
+        self.backend = backend
+        self.location = location
+
+    def as_dataframe(self, limit: int | None = None) -> "pd.DataFrame":
+        import pandas as pd
+
+        if self.backend == "memory":
+            df: pd.DataFrame = self.location
+            return df.head(limit) if limit is not None else df
+        if self.backend == "duckdb":
+            import duckdb
+
+            conn = duckdb.connect(self.location)
+            query = "SELECT * FROM flows"
+            if limit is not None:
+                query += f" LIMIT {limit}"
+            return conn.execute(query).df()
+        if self.backend == "arrow":
+            import pyarrow.dataset as ds
+
+            dataset = ds.dataset(self.location, format="ipc")
+            table = dataset.head(limit) if limit is not None else dataset.to_table()
+            return table.to_pandas()
+        raise ValueError(f"Unsupported backend: {self.backend}")
+
+    def count(self) -> int:
+        if self.backend == "memory":
+            return len(self.location)
+        if self.backend == "duckdb":
+            import duckdb
+
+            conn = duckdb.connect(self.location)
+            return conn.execute("SELECT COUNT(*) FROM flows").fetchone()[0]
+        if self.backend == "arrow":
+            import pyarrow.dataset as ds
+
+            dataset = ds.dataset(self.location, format="ipc")
+            return dataset.count_rows()
+        raise ValueError(f"Unsupported backend: {self.backend}")
+
+    def to_parquet(self, path: str) -> None:
+        if self.backend == "memory":
+            self.location.to_parquet(path, index=False)
+            return
+        if self.backend == "duckdb":
+            import duckdb
+
+            conn = duckdb.connect(self.location)
+            conn.execute(f"COPY flows TO '{path}' (FORMAT 'PARQUET')")
+            return
+        if self.backend == "arrow":
+            import pyarrow.dataset as ds
+            import pyarrow.parquet as pq
+
+            dataset = ds.dataset(self.location, format="ipc")
+            pq.write_table(dataset.to_table(), path)
+            return
+        raise ValueError(f"Unsupported backend: {self.backend}")
+
+
+__all__ = ["PcapRecord", "ParsedHandle"]

--- a/src/pcap_tool/parser.py
+++ b/src/pcap_tool/parser.py
@@ -1,5 +1,5 @@
 # src/pcap_tool/parser.py
-from dataclasses import dataclass, field, asdict
+from dataclasses import asdict
 from datetime import datetime
 from typing import List, Optional
 from typing import (
@@ -22,6 +22,7 @@ from collections import defaultdict, deque
 
 from .exceptions import CorruptPcapError
 from .heuristics.errors import detect_packet_error
+from .models import PcapRecord, ParsedHandle
 
 logger = logging.getLogger(__name__)
 
@@ -91,109 +92,6 @@ ZPA_SYNTHETIC_IP_RANGE = ipaddress.ip_network("100.64.0.0/10")
 _TCP_FLOW_HISTORY: dict[tuple[str, int, str, int], deque] = defaultdict(deque)
 _TCP_FLOW_HISTORY_MAX = 64
 
-@dataclass
-class PcapRecord:
-    frame_number: int
-    timestamp: float
-    source_ip: Optional[str] = None
-    destination_ip: Optional[str] = None
-    source_port: Optional[int] = None; destination_port: Optional[int] = None
-    protocol: Optional[str] = None; sni: Optional[str] = None; raw_packet_summary: Optional[str] = None
-    source_mac: Optional[str] = None; destination_mac: Optional[str] = None
-    protocol_l3: Optional[str] = None; packet_length: Optional[int] = None
-    ip_ttl: Optional[int] = None; ip_flags_df: Optional[bool] = None; ip_id: Optional[str] = None; dscp_value: Optional[int] = None
-    tcp_flags_syn: Optional[bool] = None; tcp_flags_ack: Optional[bool] = None; tcp_flags_fin: Optional[bool] = None
-    tcp_flags_rst: Optional[bool] = None; tcp_flags_psh: Optional[bool] = None; tcp_flags_urg: Optional[bool] = None
-    tcp_flags_ece: Optional[bool] = None; tcp_flags_cwr: Optional[bool] = None
-    tcp_sequence_number: Optional[int] = None; tcp_acknowledgment_number: Optional[int] = None
-    tcp_window_size: Optional[int] = None; tcp_options_mss: Optional[int] = None
-    tcp_options_sack_permitted: Optional[bool] = None; tcp_options_window_scale: Optional[int] = None
-    tcp_stream_index: Optional[int] = None
-    is_src_client: Optional[bool] = None
-    is_source_client: Optional[bool] = None
-    tcp_analysis_retransmission_flags: list[str] = field(default_factory=list)
-    tcp_analysis_duplicate_ack_flags: list[str] = field(default_factory=list)
-    tcp_analysis_out_of_order_flags: list[str] = field(default_factory=list)
-    tcp_analysis_window_flags: list[str] = field(default_factory=list)
-    dup_ack_num: Optional[int] = None
-    adv_window: Optional[int] = None
-    tcp_rtt_ms: Optional[float] = None
-    tls_handshake_type: Optional[str] = None; tls_handshake_version: Optional[str] = None
-    tls_record_version: Optional[str] = None; tls_cipher_suites_offered: Optional[List[str]] = None
-    tls_cipher_suite_selected: Optional[str] = None; tls_alert_message_description: Optional[str] = None
-    tls_alert_level: Optional[str] = None
-    tls_effective_version: Optional[str] = None
-    # ── TLS certificate metadata ─────────────────────────────────────────
-    tls_cert_subject_cn: Optional[str] = None
-    tls_cert_san_dns: Optional[List[str]] = None   # list of DNS SANs
-    tls_cert_san_ip: Optional[List[str]] = None    # list of IP SANs
-    tls_cert_issuer_cn: Optional[str] = None
-    tls_cert_serial_number: Optional[str] = None
-    tls_cert_not_before: Optional[datetime] = None
-    tls_cert_not_after: Optional[datetime] = None
-    tls_cert_sig_alg: Optional[str] = None
-    tls_cert_key_length: Optional[int] = None
-    tls_cert_is_self_signed: Optional[bool] = None
-    dns_query_name: Optional[str] = None; dns_query_type: Optional[str] = None
-    dns_response_code: Optional[str] = None; dns_response_addresses: Optional[List[str]] = None
-    dns_response_cname_target: Optional[str] = None
-    http_request_method: Optional[str] = None; http_request_uri: Optional[str] = None
-    http_request_host_header: Optional[str] = None; http_response_code: Optional[int] = None
-    http_response_location_header: Optional[str] = None; http_x_forwarded_for_header: Optional[str] = None
-    icmp_type: Optional[int] = None; icmp_code: Optional[int] = None
-    icmp_fragmentation_needed_original_mtu: Optional[int] = None
-    arp_opcode: Optional[int] = None; arp_sender_mac: Optional[str] = None
-    arp_sender_ip: Optional[str] = None; arp_target_mac: Optional[str] = None
-    arp_target_ip: Optional[str] = None; dhcp_message_type: Optional[str] = None
-    gre_protocol: Optional[str] = None
-    esp_spi: Optional[str] = None
-    quic_initial_packet_present: Optional[bool] = None
-    is_quic: Optional[bool] = None
-    is_zscaler_ip: Optional[bool] = None
-    is_zpa_synthetic_ip: Optional[bool] = None
-    ssl_inspection_active: Optional[bool] = None
-    zscaler_policy_block_type: Optional[str] = None
-
-    def __post_init__(self) -> None:
-        """Normalize key fields for consistency."""
-        try:
-            self.frame_number = int(self.frame_number)
-        except (TypeError, ValueError):
-            self.frame_number = 0
-        try:
-            self.timestamp = float(self.timestamp)
-        except (TypeError, ValueError):
-            self.timestamp = 0.0
-
-        if isinstance(self.source_port, str):
-            self.source_port = _safe_int(self.source_port)
-        if isinstance(self.destination_port, str):
-            self.destination_port = _safe_int(self.destination_port)
-
-        if isinstance(self.tcp_stream_index, str):
-            self.tcp_stream_index = _safe_int(self.tcp_stream_index)
-
-    def __str__(self):
-        # ... (previous __str__ content, potentially updated for new fields) ...
-        final_chunk_info = []
-        if self.gre_protocol: final_chunk_info.append(f"GRE_Proto:{self.gre_protocol}")
-        if self.esp_spi: final_chunk_info.append(f"ESP_SPI:{self.esp_spi}")
-        if self.quic_initial_packet_present is not None: final_chunk_info.append(f"QUIC_Initial:{self.quic_initial_packet_present}")
-        if self.is_quic is not None: final_chunk_info.append(f"IsQUIC:{self.is_quic}")
-        if self.is_zscaler_ip is not None: final_chunk_info.append(f"ZscalerIP:{self.is_zscaler_ip}")
-        if self.is_zpa_synthetic_ip is not None: final_chunk_info.append(f"ZPA_SynthIP:{self.is_zpa_synthetic_ip}")
-        if self.is_src_client is not None: final_chunk_info.append(f"SrcIsClient:{self.is_src_client}")
-        if self.ssl_inspection_active is not None: final_chunk_info.append(f"SSL_Inspect:{self.ssl_inspection_active}")
-        if self.zscaler_policy_block_type: final_chunk_info.append(f"ZS_Block:{self.zscaler_policy_block_type}")
-        final_chunk_str = ", ".join(final_chunk_info)
-
-        return (
-            f"Frame: {self.frame_number}, Time: {self.timestamp:.6f}, "
-            f"IP: {self.source_ip or 'N/A'}:{self.source_port or 'N/A'} -> "
-            f"{self.destination_ip or 'N/A'}:{self.destination_port or 'N/A'}, "
-            f"L4_Proto: {self.protocol or 'N/A'}, "
-            f"Extra: [{final_chunk_str if final_chunk_str else 'N/A'}], SNI: {self.sni if self.sni else 'N/A'}"
-        )
 
 def _safe_str_to_bool(value: Any) -> Optional[bool]:
     """Safely converts a string value (like '0', '1', 'true', 'false') to a boolean."""
@@ -1463,66 +1361,6 @@ def parse_pcap_to_df(
     return df
 
 
-class ParsedHandle:
-    """Represents parsed flows stored in memory or on disk."""
-
-    def __init__(self, backend: str, location: Any):
-        self.backend = backend
-        self.location = location
-
-    def as_dataframe(self, limit: int | None = None) -> pd.DataFrame:
-        if self.backend == "memory":
-            df: pd.DataFrame = self.location
-            return df.head(limit) if limit is not None else df
-        if self.backend == "duckdb":
-            import duckdb
-
-            conn = duckdb.connect(self.location)
-            query = "SELECT * FROM flows"
-            if limit is not None:
-                query += f" LIMIT {limit}"
-            return conn.execute(query).df()
-        if self.backend == "arrow":
-            import pyarrow.dataset as ds
-
-            dataset = ds.dataset(self.location, format="ipc")
-            table = dataset.head(limit) if limit is not None else dataset.to_table()
-            return table.to_pandas()
-        raise ValueError(f"Unsupported backend: {self.backend}")
-
-    def count(self) -> int:
-        if self.backend == "memory":
-            return len(self.location)
-        if self.backend == "duckdb":
-            import duckdb
-
-            conn = duckdb.connect(self.location)
-            return conn.execute("SELECT COUNT(*) FROM flows").fetchone()[0]
-        if self.backend == "arrow":
-            import pyarrow.dataset as ds
-
-            dataset = ds.dataset(self.location, format="ipc")
-            return dataset.count_rows()
-        raise ValueError(f"Unsupported backend: {self.backend}")
-
-    def to_parquet(self, path: str) -> None:
-        if self.backend == "memory":
-            self.location.to_parquet(path, index=False)
-            return
-        if self.backend == "duckdb":
-            import duckdb
-
-            conn = duckdb.connect(self.location)
-            conn.execute(f"COPY flows TO '{path}' (FORMAT 'PARQUET')")
-            return
-        if self.backend == "arrow":
-            import pyarrow.dataset as ds
-            import pyarrow.parquet as pq
-
-            dataset = ds.dataset(self.location, format="ipc")
-            pq.write_table(dataset.to_table(), path)
-            return
-        raise ValueError(f"Unsupported backend: {self.backend}")
 
 def _parse_to_duckdb(
     file_like: Path | IO[bytes],

--- a/src/pcap_tool/pipeline_app.py
+++ b/src/pcap_tool/pipeline_app.py
@@ -10,7 +10,8 @@ from typing import List, Tuple
 
 import pandas as pd
 
-from .parser import iter_parsed_frames, PcapRecord
+from .parser import iter_parsed_frames
+from .models import PcapRecord
 from .metrics.stats_collector import StatsCollector
 from .metrics.flow_table import FlowTable
 from .metrics.timeline_builder import TimelineBuilder

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -238,4 +238,3 @@ def test_rulefile_error_on_bad_yaml(tmp_path):
     bad_yaml_path.write_text(":- bad")
     with pytest.raises(RuleFileError):
         HeuristicEngine(str(bad_yaml_path))
-

--- a/tests/test_flow_protocol_guess.py
+++ b/tests/test_flow_protocol_guess.py
@@ -1,5 +1,5 @@
 from pcap_tool.metrics.flow_table import FlowTable
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 
 
 def test_flow_l7_protocol_guess():

--- a/tests/test_flow_table.py
+++ b/tests/test_flow_table.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from pcap_tool.metrics.flow_table import FlowTable
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 
 
 def test_flow_table_basic():

--- a/tests/test_flow_table_l7.py
+++ b/tests/test_flow_table_l7.py
@@ -1,5 +1,5 @@
 from pcap_tool.metrics.flow_table import FlowTable
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 
 
 def _make_record(frame, ts, sport, dport, proto):

--- a/tests/test_nan_handling.py
+++ b/tests/test_nan_handling.py
@@ -1,6 +1,6 @@
 import math
 from pcap_tool.analyze import PerformanceAnalyzer
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 from pcap_tool.pipeline_app import _derive_flow_id, _flow_cache_key
 from pcap_tool.metrics.flow_table import FlowTable
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -9,9 +9,9 @@ from dataclasses import fields # Use fields to get all PcapRecord field names
 from pcap_tool.parser import (
     parse_pcap,
     parse_pcap_to_df,
-    PcapRecord,
     validate_pcap_file,
 )
+from pcap_tool.models import PcapRecord
 from pcap_tool.exceptions import CorruptPcapError
 import shutil
 

--- a/tests/test_performance_analyzer.py
+++ b/tests/test_performance_analyzer.py
@@ -1,5 +1,5 @@
 from pcap_tool.analyze import PerformanceAnalyzer
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 
 
 def _flow_id(rec: PcapRecord, is_client: bool) -> str:

--- a/tests/test_stats_collector.py
+++ b/tests/test_stats_collector.py
@@ -8,7 +8,8 @@ from scapy.layers.inet import IP, TCP, UDP, ICMP
 
 
 from pcap_tool.metrics.stats_collector import StatsCollector
-from pcap_tool.parser import parse_pcap_to_df, PcapRecord
+from pcap_tool.parser import parse_pcap_to_df
+from pcap_tool.models import PcapRecord
 from pcap_tool.exceptions import CorruptPcapError
 
 

--- a/tests/test_timeline_builder.py
+++ b/tests/test_timeline_builder.py
@@ -1,5 +1,5 @@
 from pcap_tool.metrics.timeline_builder import TimelineBuilder
-from pcap_tool.parser import PcapRecord
+from pcap_tool.models import PcapRecord
 
 
 def test_timeline_builder_basic():


### PR DESCRIPTION
## Summary
- move `PcapRecord` and `ParsedHandle` to new `models.py`
- import the models from their new location across the codebase
- re-export `PcapRecord` and `ParsedHandle` from `pcap_tool.__init__`
- update tests for new import paths

## Testing
- `flake8 src/ tests/`
- `pytest -q`
