### PR TITLE
Refactor parser into package

### DIFF
--- a/src/pcap_tool/parser/__init__.py
+++ b/src/pcap_tool/parser/__init__.py
@@ -1,0 +1,17 @@
+from .core import (
+    parse_pcap,
+    parse_pcap_to_df,
+    iter_parsed_frames,
+    validate_pcap_file,
+    _safe_int,
+    ParserNotAvailable,
+)
+
+__all__ = [
+    "parse_pcap",
+    "parse_pcap_to_df",
+    "iter_parsed_frames",
+    "validate_pcap_file",
+    "_safe_int",
+    "ParserNotAvailable",
+]

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -20,9 +20,12 @@ from math import ceil
 from concurrent.futures import ProcessPoolExecutor
 from collections import defaultdict, deque
 
-from .exceptions import CorruptPcapError
-from .heuristics.errors import detect_packet_error
-from .models import PcapRecord, ParsedHandle
+from ..exceptions import CorruptPcapError
+from ..heuristics.errors import detect_packet_error
+from ..models import PcapRecord, ParsedHandle
+
+class ParserNotAvailable(RuntimeError):
+    """Raised when no parser backend is available."""
 
 logger = logging.getLogger(__name__)
 

--- a/src/pcap_tool/parser/helpers.py
+++ b/src/pcap_tool/parser/helpers.py
@@ -1,0 +1,3 @@
+from .core import validate_pcap_file, _safe_int, _maybe_int
+
+__all__ = ["validate_pcap_file", "_safe_int", "_maybe_int"]

--- a/src/pcap_tool/parser/pcapkit_parser.py
+++ b/src/pcap_tool/parser/pcapkit_parser.py
@@ -1,0 +1,3 @@
+from .core import _parse_with_pcapkit, _USE_PCAPKIT as USE_PCAPKIT
+
+__all__ = ["_parse_with_pcapkit", "USE_PCAPKIT"]

--- a/src/pcap_tool/parser/pyshark_parser.py
+++ b/src/pcap_tool/parser/pyshark_parser.py
@@ -1,0 +1,3 @@
+from .core import _parse_with_pyshark, _USE_PYSHARK as USE_PYSHARK
+
+__all__ = ["_parse_with_pyshark", "USE_PYSHARK"]


### PR DESCRIPTION
## Summary
- move `parser.py` into a new `parser` package
- keep backward compatibility through `parser/__init__.py`
- expose helpers via `parser/helpers.py`
- add thin wrappers `pyshark_parser.py` and `pcapkit_parser.py`
- define `ParserNotAvailable` in `core.py`

## Testing
- `flake8 src/ tests/`
- `pytest -q`