### PR TITLE
Add centralized logging module

### DIFF
--- a/src/heuristics/engine.py
+++ b/src/heuristics/engine.py
@@ -2,7 +2,7 @@ import yaml
 import pandas as pd
 import ipaddress  # For CIDR checks
 import re  # For regex checks
-import logging
+from pcap_tool.logging import get_logger
 from typing import List, Dict, Any, Optional, TypedDict, Union, Callable, Tuple
 import argparse
 import os
@@ -11,14 +11,7 @@ import sys
 from pcap_tool.exceptions import RuleFileError
 
 # Configure logging
-logger = logging.getLogger(__name__)
-# Set default logging handler to avoid "No handler found" warnings.
-if not logger.handlers:
-    handler = logging.StreamHandler(sys.stdout)
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-    logger.setLevel(logging.INFO)
+logger = get_logger(__name__)
 
 
 __all__ = ["HeuristicEngine"]

--- a/src/llm_summarizer.py
+++ b/src/llm_summarizer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-import logging
+from pcap_tool.logging import get_logger
 import os
 import time
 from typing import Optional
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import openai
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class LLMSummarizerError(Exception):

--- a/src/pcap_tool/enrichment.py
+++ b/src/pcap_tool/enrichment.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+from pcap_tool.logging import get_logger
 import socket
 from typing import Any, Optional
 
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover - library may not be installed
 
         pass
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class Enricher:

--- a/src/pcap_tool/logging.py
+++ b/src/pcap_tool/logging.py
@@ -1,0 +1,26 @@
+import logging
+import sys
+import json
+
+
+def get_logger(name: str = __name__) -> logging.Logger:
+    """Return a JSON-configured logger.
+
+    Reuses existing handlers to avoid duplicates when called multiple times.
+    """
+    logger = logging.getLogger(name)
+    if logger.handlers:
+        return logger
+    handler = logging.StreamHandler(sys.stdout)
+    fmt = json.dumps(
+        {
+            "ts": "%(asctime)s",
+            "lvl": "%(levelname)s",
+            "mod": "%(name)s",
+            "msg": "%(message)s",
+        }
+    )
+    handler.setFormatter(logging.Formatter(fmt))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger

--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import logging
+from pcap_tool.logging import get_logger
 from typing import Any, Dict, List
 
 import pandas as pd
@@ -15,7 +15,7 @@ from .enrich.service_guesser import guess_service
 from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
 from heuristics.engine import HeuristicEngine
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class MetricsBuilder:

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -10,6 +10,7 @@ from typing import (
     Callable,
 )
 import logging
+from pcap_tool.logging import get_logger
 import pandas as pd
 from pathlib import Path
 import ipaddress
@@ -27,7 +28,7 @@ from ..models import PcapRecord, ParsedHandle
 class ParserNotAvailable(RuntimeError):
     """Raised when no parser backend is available."""
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 _USE_PYSHARK = False
 _USE_PCAPKIT = False

--- a/src/pcap_tool/summary.py
+++ b/src/pcap_tool/summary.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, IO, Any
 import pandas as pd
-import logging
+from pcap_tool.logging import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 _PRIORITY_ORDER = ["Blocked", "Degraded", "Allowed", "Unknown"]


### PR DESCRIPTION
## Summary
- add `get_logger` utility for JSON-formatted logs
- use it across modules instead of `logging.getLogger(__name__)`

## Testing
- `flake8 src/ tests/`
- `pytest -q`