### PR TITLE
Add NA-safe pandas helpers

### DIFF
--- a/src/pcap_tool/analyze/security_auditor.py
+++ b/src/pcap_tool/analyze/security_auditor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Dict, List
 import pandas as pd
+from ..utils import coalesce
 
 from ..enrichment import Enricher
 
@@ -32,7 +33,7 @@ class SecurityAuditor:
                 "security_flag_plaintext_http", pd.Series(dtype=bool)
             )
             result["plaintext_http_flows"] = int(
-                plaintext_series.fillna(False).astype(bool).sum()
+                coalesce(plaintext_series, False).astype(bool).sum()
             )
 
             if "security_flag_outdated_tls_version" in tagged_flow_df.columns:
@@ -49,7 +50,7 @@ class SecurityAuditor:
                 "security_flag_self_signed_cert", pd.Series(dtype=bool)
             )
             result["self_signed_certificate_flows"] = int(
-                self_signed_series.fillna(False).astype(bool).sum()
+                coalesce(self_signed_series, False).astype(bool).sum()
             )
 
         enriched_ips = self.enricher.enrich_ips(unique_external_ips)

--- a/src/pcap_tool/pipeline_app.py
+++ b/src/pcap_tool/pipeline_app.py
@@ -22,7 +22,7 @@ from .metrics_builder import MetricsBuilder
 from heuristics.engine import HeuristicEngine
 from llm_summarizer import LLMSummarizer
 from .pdf_report import generate_pdf_report
-from .utils import safe_int_or_default
+from .utils import safe_int, safe_int_or_default
 
 
 def _derive_flow_id(rec: PcapRecord) -> Tuple[str, str, int, int, str]:
@@ -158,11 +158,9 @@ def run_analysis(pcap_path: Path, rules_path: Path) -> Tuple[dict, pd.DataFrame,
 
     for col in int_cols_to_clean:
         if col in packet_df.columns:
-            if packet_df[col].isnull().any():
-                packet_df[col] = packet_df[col].fillna(
-                    fill_values_for_int_cols.get(col, 0)
-                )
-            packet_df[col] = packet_df[col].astype("int64")
+            packet_df[col] = safe_int(
+                packet_df[col], fill_values_for_int_cols.get(col, 0)
+            )
 
     flow_summary_df, _ = flow_table.get_summary_df()
     tagged_flow_df = heuristic_engine.tag_flows(flow_summary_df)

--- a/src/pcap_tool/summary.py
+++ b/src/pcap_tool/summary.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Iterable, Optional, IO, Any
 import pandas as pd
 from pcap_tool.logging import get_logger
+from pcap_tool.utils import coalesce
 
 logger = get_logger(__name__)
 
@@ -151,15 +152,15 @@ def generate_summary_df(full_df: pd.DataFrame) -> pd.DataFrame:
         end_time = group["timestamp"].max()
         duration_ms = (end_time - start_time).total_seconds() * 1000
 
-        c2s_mask = group["is_src_client"].fillna(False) == True
-        s2c_mask = group["is_src_client"].fillna(False) == False
+        c2s_mask = coalesce(group["is_src_client"], False) == True
+        s2c_mask = coalesce(group["is_src_client"], False) == False
 
         pkts_c2s = int(c2s_mask.sum())
         pkts_s2c = int(s2c_mask.sum())
         pkts_total = pkts_c2s + pkts_s2c
 
-        bytes_c2s = group.loc[c2s_mask, length_col].fillna(0).sum()
-        bytes_s2c = group.loc[s2c_mask, length_col].fillna(0).sum()
+        bytes_c2s = coalesce(group.loc[c2s_mask, length_col], 0).sum()
+        bytes_s2c = coalesce(group.loc[s2c_mask, length_col], 0).sum()
         bytes_total = bytes_c2s + bytes_s2c
 
         flow_disp = _priority_pick(group.get("flow_disposition"))

--- a/src/pcap_tool/utils/__init__.py
+++ b/src/pcap_tool/utils/__init__.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import pandas as pd
 
+from .pandas_safe import coalesce, safe_int
+
 
 def export_to_csv(data_to_export: pd.DataFrame, filename: str) -> None:
     """Write ``data_to_export`` to ``filename`` as CSV without index."""
@@ -24,3 +26,10 @@ def safe_int_or_default(value: object, default: int = 0) -> int:
         except (TypeError, ValueError):
             pass
     return default
+
+__all__ = [
+    "export_to_csv",
+    "safe_int_or_default",
+    "safe_int",
+    "coalesce",
+]

--- a/src/pcap_tool/utils/pandas_safe.py
+++ b/src/pcap_tool/utils/pandas_safe.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def safe_int(series: pd.Series, default: int = 0) -> pd.Series:
+    """Return integer Series with ``NaN`` replaced by ``default``.
+
+    Parameters
+    ----------
+    series:
+        Series to convert.
+    default:
+        Value to use where ``series`` has ``NaN``.
+    """
+    filled = series.where(series.notna(), default)
+    if hasattr(filled, "infer_objects"):
+        filled = filled.infer_objects(copy=False)
+    return pd.to_numeric(filled, downcast="integer")
+
+
+def coalesce(series: pd.Series, fallback):
+    """Return ``series`` with ``NaN`` replaced by ``fallback``."""
+    return series.where(series.notna(), fallback)

--- a/tests/utils/test_pandas_safe.py
+++ b/tests/utils/test_pandas_safe.py
@@ -1,0 +1,16 @@
+import pandas as pd
+
+from pcap_tool.utils import safe_int, coalesce
+
+
+def test_safe_int_basic():
+    series = pd.Series([1, pd.NA, 3])
+    result = safe_int(series, default=0)
+    assert result.tolist() == [1, 0, 3]
+    assert result.dtype.kind in {"i", "u"}
+
+
+def test_coalesce_basic():
+    series = pd.Series(["a", pd.NA, "b"])
+    result = coalesce(series, "x")
+    assert result.tolist() == ["a", "x", "b"]


### PR DESCRIPTION
## Summary
- convert utils module to package
- add NA-safe helpers `safe_int` and `coalesce`
- refactor pipeline, summary and security auditor to use helpers
- add tests for new helpers

## Testing
- `flake8 src/ tests/`
- `pytest -q`