### PR TITLE
Add heuristics package init

### DIFF
--- a/src/pcap_tool/heuristics/__init__.py
+++ b/src/pcap_tool/heuristics/__init__.py
@@ -1,0 +1,10 @@
+from .protocol_inference import guess_l7_protocol
+from .metrics import count_tls_versions, compute_tcp_rtt_stats
+from .errors import detect_packet_error
+
+__all__ = [
+    "guess_l7_protocol",
+    "count_tls_versions",
+    "compute_tcp_rtt_stats",
+    "detect_packet_error",
+]


### PR DESCRIPTION
## Summary
- enable packaging of `pcap_tool.heuristics` by adding an `__init__`
- expose helper functions for easier imports

## Testing
- `flake8 src/ tests/`
- `pytest -q`