### PR TITLE
Refactor pipeline analysis helpers

### DIFF
--- a/src/pcap_tool/pipeline_app.py
+++ b/src/pcap_tool/pipeline_app.py
@@ -4,25 +4,24 @@
 from __future__ import annotations
 
 import argparse
-from dataclasses import asdict
 from pathlib import Path
 from typing import List, Tuple
 
 import pandas as pd
-
-from .parser import iter_parsed_frames
 from .models import PcapRecord
-from .metrics.stats_collector import StatsCollector
-from .metrics.flow_table import FlowTable
-from .metrics.timeline_builder import TimelineBuilder
 from .enrichment import Enricher
 from .enrich import service_guesser
-from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
+from .analyze import ErrorSummarizer, SecurityAuditor
 from .metrics_builder import MetricsBuilder
 from heuristics.engine import HeuristicEngine
 from llm_summarizer import LLMSummarizer
-from .pdf_report import generate_pdf_report
-from .utils import safe_int, safe_int_or_default
+from .utils import safe_int_or_default
+from .pipeline_helpers import (
+    load_packets,
+    collect_stats,
+    build_metrics,
+    generate_reports,
+)
 
 
 def _derive_flow_id(rec: PcapRecord) -> Tuple[str, str, int, int, str]:
@@ -60,114 +59,33 @@ def _flow_cache_key(record: PcapRecord) -> str:
 def run_analysis(pcap_path: Path, rules_path: Path) -> Tuple[dict, pd.DataFrame, str, bytes]:
     """Run the full analysis pipeline and return outputs."""
 
+    records = load_packets(pcap_path)
+    stats = collect_stats(records)
+
     enricher = Enricher()
-    stats_collector = StatsCollector()
-    flow_table = FlowTable()
     service = service_guesser
-    performance_analyzer = PerformanceAnalyzer()
-    timeline_builder = TimelineBuilder()
     error_summarizer = ErrorSummarizer()
     security_auditor = SecurityAuditor(enricher)
     heuristic_engine = HeuristicEngine(str(rules_path))
     metrics_builder = MetricsBuilder(
-        stats_collector,
-        flow_table,
+        stats["stats_collector"],
+        stats["flow_table"],
         enricher,
         service,
-        performance_analyzer,
-        timeline_builder,
+        stats["performance_analyzer"],
+        stats["timeline_builder"],
         error_summarizer,
         security_auditor,
         heuristic_engine,
     )
+
+    flow_summary_df, _ = stats["flow_table"].get_summary_df()
+    tagged_flow_df = build_metrics(flow_summary_df, rules_path)
+    metrics_json = metrics_builder.build_metrics(stats["packet_df"], tagged_flow_df)
+
     llm_summarizer = LLMSummarizer()
-
-    packet_records: List[PcapRecord] = []
-    flow_clients_cache: dict[str, tuple[str | None, int | None]] = {}
-
-    for chunk in iter_parsed_frames(pcap_path):
-        for row in chunk.itertuples(index=False):
-            rec = PcapRecord(**row._asdict())
-            stats_collector.add(rec)
-            timeline_builder.add_packet(rec)
-
-            cache_key = _flow_cache_key(rec)
-            client = flow_clients_cache.get(cache_key)
-
-            if client is None:
-                if rec.protocol and rec.protocol.upper() == "TCP" and rec.tcp_flags_syn and not rec.tcp_flags_ack:
-                    flow_clients_cache[cache_key] = (rec.source_ip, rec.source_port)
-                    is_client = True
-                elif rec.protocol and rec.protocol.upper() == "UDP":
-                    flow_clients_cache[cache_key] = (rec.source_ip, rec.source_port)
-                    is_client = True
-                else:
-                    is_client = True
-            else:
-                is_client = rec.source_ip == client[0] and rec.source_port == client[1]
-
-            rec.is_source_client = is_client
-            flow_id = _derive_flow_id(rec)
-            flow_table.add_packet(rec, is_client)
-            performance_analyzer.add_packet(rec, "-".join(map(str, flow_id)), is_client)
-            packet_records.append(rec)
-
-    packet_df = pd.DataFrame([asdict(r) for r in packet_records])
-
-    int_cols_to_clean = [
-        "source_port",
-        "destination_port",
-        "packet_length",
-        "frame_number",
-        "tcp_sequence_number",
-        "tcp_acknowledgment_number",
-        "tcp_window_size",
-        "tcp_options_mss",
-        "tcp_options_window_scale",
-        "icmp_type",
-        "icmp_code",
-        "ip_ttl",
-        "dscp_value",
-        "arp_opcode",
-        "tcp_stream_index",
-        "dup_ack_num",
-        "adv_window",
-        "icmp_fragmentation_needed_original_mtu",
-    ]
-
-    fill_values_for_int_cols = {
-        "source_port": -1,
-        "destination_port": -1,
-        "packet_length": 0,
-        "frame_number": -1,
-        "tcp_sequence_number": -1,
-        "tcp_acknowledgment_number": -1,
-        "tcp_window_size": 0,
-        "tcp_options_mss": 0,
-        "tcp_options_window_scale": 0,
-        "icmp_type": -1,
-        "icmp_code": -1,
-        "ip_ttl": 0,
-        "dscp_value": 0,
-        "arp_opcode": -1,
-        "tcp_stream_index": -1,
-        "dup_ack_num": -1,
-        "adv_window": 0,
-        "icmp_fragmentation_needed_original_mtu": 0,
-    }
-
-    for col in int_cols_to_clean:
-        if col in packet_df.columns:
-            packet_df[col] = safe_int(
-                packet_df[col], fill_values_for_int_cols.get(col, 0)
-            )
-
-    flow_summary_df, _ = flow_table.get_summary_df()
-    tagged_flow_df = heuristic_engine.tag_flows(flow_summary_df)
-    metrics_json = metrics_builder.build_metrics(packet_df, tagged_flow_df)
-
     text_summary = llm_summarizer.generate_text_summary(metrics_json)
-    pdf_bytes = generate_pdf_report(metrics_json, tagged_flow_df)
+    pdf_bytes = generate_reports(metrics_json, tagged_flow_df)
 
     return metrics_json, tagged_flow_df, text_summary, pdf_bytes
 

--- a/src/pcap_tool/pipeline_helpers.py
+++ b/src/pcap_tool/pipeline_helpers.py
@@ -1,0 +1,138 @@
+"""Helper functions for the analysis pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pandas as pd
+
+from .parser import iter_parsed_frames
+from .models import PcapRecord
+from .metrics.stats_collector import StatsCollector
+from .metrics.flow_table import FlowTable
+from .metrics.timeline_builder import TimelineBuilder
+from .analyze import PerformanceAnalyzer
+from .utils import safe_int
+
+INT_COLS: List[str] = [
+    "source_port",
+    "destination_port",
+    "packet_length",
+    "frame_number",
+    "tcp_sequence_number",
+    "tcp_acknowledgment_number",
+    "tcp_window_size",
+    "tcp_options_mss",
+    "tcp_options_window_scale",
+    "icmp_type",
+    "icmp_code",
+    "ip_ttl",
+    "dscp_value",
+    "arp_opcode",
+    "tcp_stream_index",
+    "dup_ack_num",
+    "adv_window",
+    "icmp_fragmentation_needed_original_mtu",
+]
+
+FILL_VALUES: Dict[str, int] = {
+    "source_port": -1,
+    "destination_port": -1,
+    "packet_length": 0,
+    "frame_number": -1,
+    "tcp_sequence_number": -1,
+    "tcp_acknowledgment_number": -1,
+    "tcp_window_size": 0,
+    "tcp_options_mss": 0,
+    "tcp_options_window_scale": 0,
+    "icmp_type": -1,
+    "icmp_code": -1,
+    "ip_ttl": 0,
+    "dscp_value": 0,
+    "arp_opcode": -1,
+    "tcp_stream_index": -1,
+    "dup_ack_num": -1,
+    "adv_window": 0,
+    "icmp_fragmentation_needed_original_mtu": 0,
+}
+
+
+def _determine_client(
+    rec: PcapRecord, cache: Dict[str, tuple[str | None, int | None]], key: str
+) -> bool:
+    client = cache.get(key)
+    if client is None:
+        if (
+            rec.protocol
+            and rec.protocol.upper() == "TCP"
+            and rec.tcp_flags_syn
+            and not rec.tcp_flags_ack
+        ) or (rec.protocol and rec.protocol.upper() == "UDP"):
+            cache[key] = (rec.source_ip, rec.source_port)
+        return True
+    return rec.source_ip == client[0] and rec.source_port == client[1]
+
+
+def _clean_int_columns(df: pd.DataFrame) -> None:
+    for col in INT_COLS:
+        if col in df.columns:
+            df[col] = safe_int(df[col], FILL_VALUES.get(col, 0))
+
+
+def load_packets(pcap_path: Path) -> List[PcapRecord]:
+    """Parse ``pcap_path`` into a list of :class:`PcapRecord`."""
+    records: List[PcapRecord] = []
+    field_set = set(PcapRecord.__dataclass_fields__.keys())
+    for chunk in iter_parsed_frames(pcap_path):
+        for row in chunk.itertuples(index=False):
+            data = {k: getattr(row, k) for k in field_set if hasattr(row, k)}
+            records.append(PcapRecord(**data))
+    return records
+
+
+def collect_stats(records: List[PcapRecord]) -> dict[str, Any]:
+    """Return packet dataframe and metric collectors for ``records``."""
+    from .pipeline_app import _derive_flow_id, _flow_cache_key
+
+    sc = StatsCollector()
+    ft = FlowTable()
+    tl = TimelineBuilder()
+    pa = PerformanceAnalyzer()
+    cache: Dict[str, tuple[str | None, int | None]] = {}
+
+    for rec in records:
+        sc.add(rec)
+        tl.add_packet(rec)
+        key = _flow_cache_key(rec)
+        rec.is_source_client = _determine_client(rec, cache, key)
+        fid = _derive_flow_id(rec)
+        ft.add_packet(rec, rec.is_source_client)
+        pa.add_packet(rec, "-".join(map(str, fid)), rec.is_source_client)
+
+    packet_df = pd.DataFrame([asdict(r) for r in records])
+    _clean_int_columns(packet_df)
+
+    return {
+        "packet_df": packet_df,
+        "stats_collector": sc,
+        "flow_table": ft,
+        "performance_analyzer": pa,
+        "timeline_builder": tl,
+    }
+
+
+def build_metrics(df: pd.DataFrame, heuristics_rules: Path) -> pd.DataFrame:
+    """Tag ``df`` flows using the provided heuristic rules."""
+    from heuristics.engine import HeuristicEngine
+
+    engine = HeuristicEngine(str(heuristics_rules))
+    return engine.tag_flows(df)
+
+
+def generate_reports(metrics: dict, flows_df: pd.DataFrame) -> bytes:
+    """Return PDF bytes for the provided metrics."""
+    from .pdf_report import generate_pdf_report
+
+    return generate_pdf_report(metrics, flows_df)

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -1,0 +1,51 @@
+import pandas as pd
+import pytest
+from pathlib import Path
+
+from pcap_tool.pipeline_helpers import (
+    load_packets,
+    collect_stats,
+    build_metrics,
+    generate_reports,
+)
+from pcap_tool.models import PcapRecord
+
+
+def test_load_packets(example_pcap: Path):
+    records = load_packets(example_pcap)
+    assert records
+    assert isinstance(records[0], PcapRecord)
+
+
+def test_collect_stats_basic():
+    records = [
+        PcapRecord(frame_number=1, timestamp=1.0, protocol="TCP"),
+        PcapRecord(frame_number=2, timestamp=2.0, protocol="TCP"),
+    ]
+    result = collect_stats(records)
+    assert set(result.keys()) == {
+        "packet_df",
+        "stats_collector",
+        "flow_table",
+        "performance_analyzer",
+        "timeline_builder",
+    }
+    assert len(result["packet_df"]) == 2
+
+
+def test_build_metrics(tmp_path: Path):
+    records = [PcapRecord(frame_number=1, timestamp=1.0, protocol="TCP")]
+    stats = collect_stats(records)
+    df, _ = stats["flow_table"].get_summary_df()
+    rules = Path("src/heuristics/rules.yaml")
+    tagged = build_metrics(df, rules)
+    assert isinstance(tagged, pd.DataFrame)
+    assert len(tagged) == len(df)
+
+
+def test_generate_reports(monkeypatch):
+    monkeypatch.setattr(
+        "pcap_tool.pdf_report.generate_pdf_report", lambda metrics, df: b"pdf"
+    )
+    pdf = generate_reports({}, pd.DataFrame())
+    assert pdf == b"pdf"


### PR DESCRIPTION
## Summary
- factor packet processing helpers into new `pipeline_helpers` module
- simplify `run_analysis` to use the helpers
- add tests for the new helper functions

## Testing
- `flake8 src/ tests/`
- `pytest -q`
- `radon cc -s src/pcap_tool/pipeline_app.py` *(fails: command not found)*