### PR TITLE
Add API docs generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,3 +54,24 @@ jobs:
         run: flake8 src/ tests/
       - name: Test
         run: pytest -q
+
+  docs:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .[dev]
+          pip install -r requirements.txt
+      - name: Build docs
+        run: make -C docs html
+      - name: Upload docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: docs/_build

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-wheel-metadata/
 
 # OS specific
 Thumbs.db
+
+# Documentation build artifacts
+docs/_build/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,9 @@
+HTML_DIR := _build
+
+.PHONY: html
+html:
+	PYTHONPATH=../src ../pdoc --html pcap_tool -o $(HTML_DIR) --force
+
+.PHONY: clean
+clean:
+	rm -rf $(HTML_DIR)

--- a/pdoc
+++ b/pdoc
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import argparse
+import importlib
+import os
+import sys
+import pydoc
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--html', action='store_true')
+    parser.add_argument('-o', '--output-dir', default='.')
+    parser.add_argument('--force', action='store_true')
+    parser.add_argument('modules', nargs='+')
+    args = parser.parse_args()
+
+    if not args.html:
+        parser.error('only --html mode supported')
+
+    os.makedirs(args.output_dir, exist_ok=True)
+    entries = []
+    for mod_name in args.modules:
+        mod = importlib.import_module(mod_name)
+        html = pydoc.HTMLDoc().docmodule(mod)
+        fname = mod_name.replace('.', '_') + '.html'
+        with open(os.path.join(args.output_dir, fname), 'w') as f:
+            f.write(html)
+        entries.append(f'<li><a href="{fname}">{mod_name}</a></li>')
+
+    index = '<html><body><h1>API Documentation</h1><ul>' + ''.join(entries) + '</ul></body></html>'
+    with open(os.path.join(args.output_dir, 'index.html'), 'w') as f:
+        f.write(index)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,3 +39,4 @@ python-dotenv                   # For loading .env files (as per README)
 requests                        # General-purpose HTTP library (often a dependency or useful for integrations)
 reportlab
 radon
+pdoc


### PR DESCRIPTION
## Summary
- add pdoc to requirements
- generate docs via Makefile using custom `pdoc` shim
- upload docs artifact in CI
- ignore docs build directory

## Testing
- `flake8 src/ tests/`
- `pytest -q`
- `make -C docs clean html`