### PR TITLE
Add retransmission severity metric and UI status pill

### DIFF
--- a/src/pcap_tool/metrics/retransmission.py
+++ b/src/pcap_tool/metrics/retransmission.py
@@ -1,0 +1,18 @@
+"""Helpers for analyzing TCP retransmission ratios."""
+
+from __future__ import annotations
+
+
+def categorize_retransmission_severity(ratio: float) -> dict[str, str]:
+    """Return a status label and color based on ``ratio``.
+
+    Parameters
+    ----------
+    ratio:
+        TCP retransmission ratio as a percentage.
+    """
+    if ratio < 1.0:
+        return {"status": "Healthy", "color": "#28a745"}
+    if ratio <= 3.0:
+        return {"status": "Warning", "color": "#ffc107"}
+    return {"status": "Critical", "color": "#dc3545"}

--- a/src/streamlit_theme.css
+++ b/src/streamlit_theme.css
@@ -1,0 +1,7 @@
+.status-pill {
+    border-radius: 10px;
+    padding: 2px 8px;
+    color: #fff;
+    font-weight: bold;
+    display: inline-block;
+}

--- a/tests/metrics/test_retransmission.py
+++ b/tests/metrics/test_retransmission.py
@@ -1,0 +1,16 @@
+from pcap_tool.metrics.retransmission import categorize_retransmission_severity
+
+
+def test_retransmission_severity_categories():
+    assert categorize_retransmission_severity(0.5) == {
+        "status": "Healthy",
+        "color": "#28a745",
+    }
+    assert categorize_retransmission_severity(1.5) == {
+        "status": "Warning",
+        "color": "#ffc107",
+    }
+    assert categorize_retransmission_severity(5.0) == {
+        "status": "Critical",
+        "color": "#dc3545",
+    }


### PR DESCRIPTION
## Summary
- implement `categorize_retransmission_severity` helper
- display retransmission severity pill in Streamlit UI
- load optional theme CSS and add `.status-pill` style
- test retransmission severity helper

## Testing
- `flake8 src/ tests/`
- `pytest -q`