### PR TITLE
Refactor RTT metrics handling

### DIFF
--- a/src/pcap_tool/analyze/security_auditor.py
+++ b/src/pcap_tool/analyze/security_auditor.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 import pandas as pd
 from ..utils import coalesce
 
-from ..enrichment import Enricher
+if TYPE_CHECKING:  # pragma: no cover - for type hints only
+    from ..enrichment import Enricher
 
 
 class SecurityAuditor:

--- a/src/pcap_tool/app.py
+++ b/src/pcap_tool/app.py
@@ -101,7 +101,17 @@ if metrics_output is not None:
     """,
                 unsafe_allow_html=True,
             )
-            st.json(perf)
+            if perf.get("rtt_limited_data"):
+                st.markdown(
+                    "<span class='status-pill' style='background:#ffc107;color:black;'>Limited RTT data available</span>",
+                    unsafe_allow_html=True,
+                )
+            else:
+                st.json(perf.get("tcp_rtt_ms", {}))
+            st.write(
+                "Retransmission Ratio: "
+                f"{perf.get('tcp_retransmission_ratio_percent', 0.0):.2f}%"
+            )
 
         proto_counts = metrics_output.get("protocols", {})
         if proto_counts:

--- a/tests/test_performance_analyzer.py
+++ b/tests/test_performance_analyzer.py
@@ -45,6 +45,7 @@ def test_tcp_rtt_basic():
     assert rtt["samples"] == 1
     assert 199 <= rtt["median"] <= 201
     assert summary["tcp_retransmission_ratio_percent"] == 0.0
+    assert summary["rtt_limited_data"] is False
 
 
 def test_tcp_retransmission_ratio():
@@ -60,3 +61,17 @@ def test_tcp_retransmission_ratio():
 
     summary = analyzer.get_summary()
     assert summary["tcp_retransmission_ratio_percent"] == 25.0
+
+
+def test_rtt_limited_data_flag():
+    analyzer = PerformanceAnalyzer()
+    syn = PcapRecord(
+        frame_number=1,
+        timestamp=1.0,
+        protocol="TCP",
+        tcp_flags_syn=True,
+        tcp_flags_ack=False,
+    )
+    analyzer.add_packet(syn, "f", True)
+    summary = analyzer.get_summary()
+    assert summary["rtt_limited_data"] is True

--- a/tests/test_tcp_rtt.py
+++ b/tests/test_tcp_rtt.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from pcap_tool.parser import parse_pcap_to_df
 from pcap_tool.heuristics.metrics import compute_tcp_rtt_stats
+from pcap_tool.analyze.performance_analyzer import PerformanceAnalyzer
 
 
 def _create_pcap(packets, tmp_path: Path, name: str) -> Path:
@@ -48,3 +49,16 @@ def test_compute_tcp_rtt_stats_empty():
     assert result["samples"] == 0
     assert result["median"] is None
     assert "reason" in result
+
+
+def test_collect_rtt_samples_basic(handshake_pcap: Path):
+    df = parse_pcap_to_df(str(handshake_pcap))
+    samples = PerformanceAnalyzer.collect_rtt_samples(df)
+    assert len(samples) == 1
+    assert 999 <= samples[0] <= 1001
+
+
+def test_collect_rtt_samples_none(syn_only_pcap: Path):
+    df = parse_pcap_to_df(str(syn_only_pcap))
+    samples = PerformanceAnalyzer.collect_rtt_samples(df)
+    assert samples == []


### PR DESCRIPTION
## Summary
- add `collect_rtt_samples` helper and limited data handling in `PerformanceAnalyzer`
- show a yellow badge in Streamlit UI when RTT data is limited
- avoid importing Enricher at module load for `SecurityAuditor`
- adjust tests for RTT logic

## Testing
- `flake8 src/ tests`
- `pytest -q`