### PR TITLE
Add capture summary section to PDF report

### DIFF
--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -26,7 +26,27 @@ def _build_elements(metrics_json: Dict[str, Any], flows_df: Optional[pd.DataFram
     elements.append(Spacer(1, 12))
 
     if capture_info:
-        for k, v in capture_info.items():
+        elements.append(Paragraph("Capture Summary", styles["Heading2"]))
+        filename = capture_info.get("filename")
+        if filename is not None:
+            elements.append(Paragraph(f"Filename: {filename}", styles["Normal"]))
+        size = capture_info.get("file_size")
+        if size is not None:
+            elements.append(Paragraph(f"File size: {size}", styles["Normal"]))
+        packets = capture_info.get("total_packets")
+        if packets is not None:
+            elements.append(Paragraph(f"Total packets: {packets}", styles["Normal"]))
+        duration = capture_info.get("capture_duration")
+        if duration is not None:
+            elements.append(Paragraph(f"Capture duration: {duration}", styles["Normal"]))
+
+        other_keys = {
+            k: v
+            for k, v in capture_info.items()
+            if k
+            not in {"filename", "file_size", "total_packets", "capture_duration"}
+        }
+        for k, v in other_keys.items():
             elements.append(Paragraph(f"{k}: {v}", styles["Normal"]))
         elements.append(Spacer(1, 12))
 

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcap_tool.pdf_report import generate_pdf_report
+from pcap_tool.pdf_report import generate_pdf_report, _build_elements
 from pcap_tool.exceptions import ReportGenerationError
 
 
@@ -33,3 +33,24 @@ def test_generate_pdf_report_error(monkeypatch):
 
     with pytest.raises(ReportGenerationError):
         generate_pdf_report({})
+
+
+def test_capture_summary_section():
+    metrics = {
+        "capture_info": {
+            "filename": "summary.pcap",
+            "file_size": 1024,
+            "total_packets": 5,
+            "capture_duration": 1.2,
+        }
+    }
+    try:
+        from reportlab.lib.styles import getSampleStyleSheet
+    except Exception:
+        pytest.skip("ReportLab not installed")
+
+    styles = getSampleStyleSheet()
+    elements = _build_elements(metrics, None, styles)
+    texts = [e.text for e in elements if hasattr(e, "text")]
+    assert "Capture Summary" in texts
+    assert any("Filename" in t for t in texts)


### PR DESCRIPTION
## Summary
- show capture metadata at start of PDF reports
- test that capture summary info is added to PDF

## Testing
- `flake8 src/ tests/`
- `pytest -q`