### PR TITLE
Enhance sparkline visuals in PDF reports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ plotly
 
 # Charting
 plotly
+matplotlib
 
 # Utilities
 python-dotenv                   # For loading .env files (as per README)


### PR DESCRIPTION
## Summary
- generate small bar charts for sparkline columns in `pdf_report`
- fallback to numeric trend summaries if matplotlib is unavailable
- include matplotlib dependency

## Testing
- `flake8 src/ tests/`
- `pytest -q`