### PR TITLE
Enhance PDF reports with AI summary and prioritized flows

### DIFF
--- a/src/pcap_tool/pipeline_app.py
+++ b/src/pcap_tool/pipeline_app.py
@@ -89,7 +89,7 @@ def run_analysis(
 
     llm_summarizer = LLMSummarizer()
     text_summary = llm_summarizer.generate_text_summary(metrics_json)
-    pdf_bytes = generate_reports(metrics_json, tagged_flow_df)
+    pdf_bytes = generate_reports(metrics_json, tagged_flow_df, text_summary)
 
     return metrics_json, tagged_flow_df, text_summary, pdf_bytes
 

--- a/src/pcap_tool/pipeline_helpers.py
+++ b/src/pcap_tool/pipeline_helpers.py
@@ -145,8 +145,8 @@ def build_metrics(df: pd.DataFrame, heuristics_rules: Path) -> pd.DataFrame:
     return engine.tag_flows(df)
 
 
-def generate_reports(metrics: dict, flows_df: pd.DataFrame) -> bytes:
+def generate_reports(metrics: dict, flows_df: pd.DataFrame, summary_text: str | None = None) -> bytes:
     """Return PDF bytes for the provided metrics."""
     from .pdf_report import generate_pdf_report
 
-    return generate_pdf_report(metrics, flows_df)
+    return generate_pdf_report(metrics, flows_df, summary_text)

--- a/tests/test_pipeline_helpers.py
+++ b/tests/test_pipeline_helpers.py
@@ -45,7 +45,7 @@ def test_build_metrics(tmp_path: Path):
 
 def test_generate_reports(monkeypatch):
     monkeypatch.setattr(
-        "pcap_tool.pdf_report.generate_pdf_report", lambda metrics, df: b"pdf"
+        "pcap_tool.pdf_report.generate_pdf_report", lambda metrics, df, summary=None: b"pdf"
     )
-    pdf = generate_reports({}, pd.DataFrame())
+    pdf = generate_reports({}, pd.DataFrame(), "text")
     assert pdf == b"pdf"


### PR DESCRIPTION
## Summary
- include AI generated summary text in PDF reports
- prioritize flows with security issues or blocked/degraded disposition
- expose summary text through pipeline helpers and CLI pipeline
- add helper for scoring top flows
- test new summary section and flow selection logic

## Testing
- `flake8 src/ tests/`
- `pytest -q`