### PR TITLE
Improve top flows ranking

### DIFF
--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -309,7 +309,11 @@ def generate_pdf_report(
 
     flows_df = top_flows_df
     if flows_df is None:
-        records = metrics_json.get("top_talkers_by_bytes") or []
+        records = (
+            metrics_json.get("top_flows")
+            or metrics_json.get("top_talkers_by_bytes")
+            or []
+        )
         if records:
             flows_df = pd.DataFrame(records)
 

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -83,3 +83,35 @@ def test_select_top_flows_scoring():
     result = _select_top_flows(df, count=3)
     assert result.iloc[0]["flow_disposition"].startswith("Blocked")
     assert result.iloc[1]["flow_disposition"] == "Degraded"
+
+
+def test_select_top_flows_metrics_builder():
+    import pandas as pd
+    from pcap_tool.metrics_builder import select_top_flows
+
+    df = pd.DataFrame(
+        [
+            {"flow_disposition": "Allowed", "bytes_total": 1000, "security_observation": "None"},
+            {"flow_disposition": "Blocked - Test", "bytes_total": 10, "security_observation": "alert"},
+            {"flow_disposition": "Degraded", "bytes_total": 20, "security_observation": "None"},
+        ]
+    )
+
+    result = select_top_flows(df, count=3)
+    assert result.iloc[0]["flow_disposition"].startswith("Blocked")
+    assert result.iloc[1]["flow_disposition"] == "Degraded"
+
+
+def test_generate_pdf_report_with_top_flows_key():
+    metrics = {
+        "capture_info": {"filename": "test.pcap"},
+        "top_flows": [
+            {"flow_disposition": "Blocked - Test", "bytes_total": 10},
+            {"flow_disposition": "Allowed", "bytes_total": 1000},
+        ],
+    }
+    try:
+        pdf_bytes = generate_pdf_report(metrics)
+    except ImportError:
+        pytest.skip("ReportLab not installed")
+    assert isinstance(pdf_bytes, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- prioritize top flows by disposition and security observations
- expose ranking logic in metrics builder and include top flows in metrics
- use top_flows in reports when available
- test ranking helper and PDF generation using new top_flows key

## Testing
- `flake8 src/ tests/`
- `pytest -q`