### PR TITLE
Improve top flows ranking

### DIFF
--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,6 +1,6 @@
 import pytest
 
-from pcap_tool.pdf_report import generate_pdf_report, _build_elements, _select_top_flows
+from pcap_tool.pdf_report import generate_pdf_report, _build_elements
 from pcap_tool.exceptions import ReportGenerationError
 
 
@@ -71,6 +71,7 @@ def test_ai_summary_section():
 
 def test_select_top_flows_scoring():
     import pandas as pd
+    from pcap_tool.metrics_builder import select_top_flows
 
     df = pd.DataFrame(
         [
@@ -80,6 +81,38 @@ def test_select_top_flows_scoring():
         ]
     )
 
-    result = _select_top_flows(df, count=3)
+    result = select_top_flows(df, count=3)
     assert result.iloc[0]["flow_disposition"].startswith("Blocked")
     assert result.iloc[1]["flow_disposition"] == "Degraded"
+
+
+def test_select_top_flows_metrics_builder():
+    import pandas as pd
+    from pcap_tool.metrics_builder import select_top_flows
+
+    df = pd.DataFrame(
+        [
+            {"flow_disposition": "Allowed", "bytes_total": 1000, "security_observation": "None"},
+            {"flow_disposition": "Blocked - Test", "bytes_total": 10, "security_observation": "alert"},
+            {"flow_disposition": "Degraded", "bytes_total": 20, "security_observation": "None"},
+        ]
+    )
+
+    result = select_top_flows(df, count=3)
+    assert result.iloc[0]["flow_disposition"].startswith("Blocked")
+    assert result.iloc[1]["flow_disposition"] == "Degraded"
+
+
+def test_generate_pdf_report_with_top_flows_key():
+    metrics = {
+        "capture_info": {"filename": "test.pcap"},
+        "top_flows": [
+            {"flow_disposition": "Blocked - Test", "bytes_total": 10},
+            {"flow_disposition": "Allowed", "bytes_total": 1000},
+        ],
+    }
+    try:
+        pdf_bytes = generate_pdf_report(metrics)
+    except ImportError:
+        pytest.skip("ReportLab not installed")
+    assert isinstance(pdf_bytes, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- prioritize top flows by disposition and security observations
- expose ranking logic in metrics builder and include top flows in metrics
- use top_flows in reports when available
- test ranking helper and PDF generation using new top_flows key

## Testing
- `flake8 src/ tests/`
- `pytest -q`
