### PR TITLE
Improve top flows ranking

### DIFF
--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -3,23 +3,66 @@
 from __future__ import annotations
 
 from pcap_tool.logging import get_logger
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TYPE_CHECKING
+
+import re
 
 import pandas as pd
 
 from .metrics.flow_table import FlowTable
 from .metrics.stats_collector import StatsCollector
 from .metrics.timeline_builder import TimelineBuilder
-from .enrichment import Enricher
 from .enrich.service_guesser import guess_service
 from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
 from heuristics.engine import HeuristicEngine
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
+    from .enrichment import Enricher
 
 logger = get_logger(__name__)
 
 # Country codes considered "common" in most enterprise traffic. Connections to
 # destinations outside this set are flagged as unusual.
 DEFAULT_COMMON_COUNTRIES = {"US", "CA", "GB", "DE", "FR", "NL", "JP", "AU"}
+
+
+def select_top_flows(flows_df: pd.DataFrame, count: int = 20) -> pd.DataFrame:
+    """Return flows ordered by diagnostic relevance."""
+
+    if flows_df is None or flows_df.empty:
+        return flows_df
+
+    def _score(row: pd.Series) -> float:
+        score = 0.0
+        disposition = str(row.get("flow_disposition", ""))
+        if disposition.startswith("Blocked"):
+            score += 1000
+        elif "Degraded" in disposition:
+            score += 500
+
+        obs = row.get("security_observations", row.get("security_observation"))
+        if isinstance(obs, str):
+            cleaned = obs.strip()
+            # Check for formally defined 'none' string representing no observation
+            if cleaned and cleaned.lower() != "none":
+                score += 200 * len([o for o in re.split(r"[;,]+", cleaned) if o.strip()])
+        elif obs not in (None, ""):
+            try:
+                score += 200 * len(obs)
+            except Exception:
+                score += 200
+
+        bytes_total = row.get("bytes_total")
+        try:
+            score += float(bytes_total) / 1_000_000
+        except Exception:
+            pass
+        return score
+
+    df = flows_df.copy()
+    df["__score"] = df.apply(_score, axis=1)
+    df = df.sort_values("__score", ascending=False).drop(columns=["__score"])
+    return df.head(count)
 
 
 class MetricsBuilder:
@@ -44,7 +87,7 @@ class MetricsBuilder:
         self,
         stats_collector: StatsCollector,
         flow_table: FlowTable,
-        enricher: Enricher,
+        enricher: "Enricher",
         service_guesser: Any,
         performance_analyzer: PerformanceAnalyzer,
         timeline_builder: TimelineBuilder,
@@ -158,6 +201,13 @@ class MetricsBuilder:
             bytes_val = row.get("bytes_total")
             entry["bytes"] += int(bytes_val) if pd.notna(bytes_val) else 0
         metrics["service_overview"] = service_overview
+
+        # Top flows based on diagnostic relevance
+        metrics["top_flows"] = (
+            select_top_flows(tagged_flow_df).to_dict(orient="records")
+            if not tagged_flow_df.empty
+            else []
+        )
 
         # Error summary
         metrics["error_summary"] = self.error_summarizer.summarize_errors(tagged_flow_df)

--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -12,45 +12,7 @@ import pandas as pd
 
 from .chart_generator import protocol_pie_chart, top_ports_bar_chart
 from .exceptions import ReportGenerationError
-
-
-def _select_top_flows(flows_df: pd.DataFrame, count: int = 20) -> pd.DataFrame:
-    """Return flows ordered by diagnostic relevance."""
-
-    if flows_df is None or flows_df.empty:
-        return flows_df
-
-    def _score(row: pd.Series) -> float:
-        score = 0.0
-        disposition = str(row.get("flow_disposition", ""))
-        if disposition.startswith("Blocked"):
-            score += 1000
-        elif "Degraded" in disposition:
-            score += 500
-
-        obs = row.get("security_observations")
-        if obs is None:
-            obs = row.get("security_observation")
-        if isinstance(obs, str):
-            if obs and obs != "None":
-                score += 200 * len([o for o in re.split(r"[;,]+", obs) if o.strip()])
-        elif obs not in (None, ""):
-            try:
-                score += 200 * len(obs)
-            except Exception:
-                score += 200
-
-        bytes_total = row.get("bytes_total")
-        try:
-            score += float(bytes_total) / 1_000_000
-        except Exception:
-            pass
-        return score
-
-    df = flows_df.copy()
-    df["__score"] = df.apply(_score, axis=1)
-    df = df.sort_values("__score", ascending=False).drop(columns=["__score"])
-    return df.head(count)
+from .metrics_builder import select_top_flows
 
 
 def _sparkline_chart(values: list[int]) -> bytes:
@@ -146,7 +108,7 @@ def _build_elements(
         elements.append(Spacer(1, 12))
 
     if flows_df is not None and not flows_df.empty:
-        flows_df = _select_top_flows(flows_df)
+        flows_df = select_top_flows(flows_df)
         elements.append(Paragraph("Top Flows", styles["Heading2"]))
 
         preferred_cols = [
@@ -309,7 +271,11 @@ def generate_pdf_report(
 
     flows_df = top_flows_df
     if flows_df is None:
-        records = metrics_json.get("top_talkers_by_bytes") or []
+        records = (
+            metrics_json.get("top_flows")
+            or metrics_json.get("top_talkers_by_bytes")
+            or []
+        )
         if records:
             flows_df = pd.DataFrame(records)
 

--- a/tests/test_pdf_report.py
+++ b/tests/test_pdf_report.py
@@ -1,6 +1,7 @@
 import pytest
 
-from pcap_tool.pdf_report import generate_pdf_report, _build_elements, _select_top_flows
+from pcap_tool.pdf_report import generate_pdf_report, _build_elements
+from pcap_tool.metrics_builder import select_top_flows
 from pcap_tool.exceptions import ReportGenerationError
 
 
@@ -80,6 +81,21 @@ def test_select_top_flows_scoring():
         ]
     )
 
-    result = _select_top_flows(df, count=3)
+    result = select_top_flows(df, count=3)
     assert result.iloc[0]["flow_disposition"].startswith("Blocked")
     assert result.iloc[1]["flow_disposition"] == "Degraded"
+
+
+def test_generate_pdf_report_with_top_flows_key():
+    metrics = {
+        "capture_info": {"filename": "test.pcap"},
+        "top_flows": [
+            {"flow_disposition": "Blocked - Test", "bytes_total": 10},
+            {"flow_disposition": "Allowed", "bytes_total": 1000},
+        ],
+    }
+    try:
+        pdf_bytes = generate_pdf_report(metrics)
+    except ImportError:
+        pytest.skip("ReportLab not installed")
+    assert isinstance(pdf_bytes, (bytes, bytearray))


### PR DESCRIPTION
## Summary
- prioritize top flows by disposition and security observations
- expose ranking logic in metrics builder and include top flows in metrics
- use top_flows in reports when available
- test ranking helper and PDF generation using new top_flows key
- move select_top_flows import to module level and simplify obs check

## Testing
- `flake8 src/ tests/`
- `pytest -q`
