### PR TITLE
Improve error & security display

### DIFF
--- a/src/pcap_tool/analyze/error_summarizer.py
+++ b/src/pcap_tool/analyze/error_summarizer.py
@@ -49,3 +49,35 @@ class ErrorSummarizer:
                     "sample_flow_ids": sample_ids,
                 }
         return result
+
+    def get_total_error_count(self, error_summary: Dict[str, Dict]) -> int:
+        """Return the total number of errors from ``error_summary``."""
+        total = 0
+        for info in error_summary.values():
+            if isinstance(info, dict) and "count" in info:
+                total += int(info.get("count", 0))
+            elif isinstance(info, dict):
+                for detail in info.values():
+                    if isinstance(detail, dict):
+                        total += int(detail.get("count", 0))
+        return total
+
+    def get_error_details_for_dataframe(self, error_summary: Dict[str, Dict]) -> List[Dict[str, object]]:
+        """Convert ``error_summary`` to a list of dicts for DataFrame display."""
+        rows: List[Dict[str, object]] = []
+        for err_type, info in error_summary.items():
+            if isinstance(info, dict) and "count" in info:
+                rows.append({
+                    "Type": err_type,
+                    "Description": "",
+                    "Count": info.get("count", 0),
+                })
+            elif isinstance(info, dict):
+                for detail, d in info.items():
+                    if isinstance(d, dict):
+                        rows.append({
+                            "Type": err_type,
+                            "Description": detail,
+                            "Count": d.get("count", 0),
+                        })
+        return rows

--- a/src/pcap_tool/analyze/security_auditor.py
+++ b/src/pcap_tool/analyze/security_auditor.py
@@ -87,3 +87,16 @@ class SecurityAuditor:
 
         result["connections_to_unusual_countries"] = unusual_connections
         return result
+
+    def get_total_security_issue_count(self, security_findings: Dict[str, object]) -> int:
+        """Return the total number of security issues in ``security_findings``."""
+        count = 0
+        count += int(security_findings.get("plaintext_http_flows") or 0)
+        count += int(security_findings.get("self_signed_certificate_flows") or 0)
+        outdated = security_findings.get("outdated_tls_version_counts") or {}
+        if isinstance(outdated, dict):
+            count += sum(int(v) for v in outdated.values())
+        unusual = security_findings.get("connections_to_unusual_countries") or {}
+        if isinstance(unusual, dict):
+            count += len(unusual)
+        return count

--- a/src/pcap_tool/utils/__init__.py
+++ b/src/pcap_tool/utils/__init__.py
@@ -4,6 +4,7 @@ import pandas as pd
 
 from .pandas_safe import coalesce, safe_int
 from .net import anonymize_ip
+from .presentation import render_status_pill
 
 
 def export_to_csv(data_to_export: pd.DataFrame, filename: str) -> None:
@@ -34,4 +35,5 @@ __all__ = [
     "safe_int",
     "coalesce",
     "anonymize_ip",
+    "render_status_pill",
 ]

--- a/src/pcap_tool/utils/presentation.py
+++ b/src/pcap_tool/utils/presentation.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+"""Helper utilities for streamlit presentation elements."""
+
+
+def render_status_pill(label: str, count: int, is_error: bool = True) -> str:
+    """Return HTML for a colored status pill.
+
+    Parameters
+    ----------
+    label:
+        Descriptive label for the pill.
+    count:
+        Number of issues or items related to ``label``.
+    is_error:
+        If ``True`` a non-zero ``count`` will render a red pill with a
+        cross mark. Otherwise a green pill with a check mark is used.
+    """
+    if count == 0:
+        text = f"\u2713 No {label.lower()}" if label else "\u2713 No issues"
+        color = "#28a745"
+    else:
+        icon = "\u2717" if is_error else "\u2713"
+        color = "#dc3545" if is_error else "#28a745"
+        text = f"{icon} {count} {label}"
+    return f"<span class='status-pill' style='background:{color};'>{text}</span>"


### PR DESCRIPTION
## Summary
- add `render_status_pill` helper for nicer pills
- show overview of errors & security findings in the Overview tab
- improve Errors & Security tab with pills, tables and debug expander
- refactor counting logic using helper methods

## Testing
- `flake8 src/ tests/`
- `pytest -q`
