### PR TITLE
Fix heuristics imports

### DIFF
--- a/src/pcap_tool/heuristics/engine.py
+++ b/src/pcap_tool/heuristics/engine.py
@@ -3,6 +3,34 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Callable, Dict, Optional
 
+_LegacyHeuristicEngine = None
+_legacy_heuristic_engine_import_error: Optional[Exception] = None
+
+try:  # pragma: no cover - optional dependency
+    from heuristics.engine import HeuristicEngine as _ImportedLegacyHeuristicEngine  # type: ignore
+    _LegacyHeuristicEngine = _ImportedLegacyHeuristicEngine
+except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover - fallback if not available
+    _legacy_heuristic_engine_import_error = e
+
+if _LegacyHeuristicEngine is not None:
+    HeuristicEngine = _LegacyHeuristicEngine  # type: ignore
+else:
+    class HeuristicEngine:  # type: ignore
+        def __init__(self, *args, **kwargs) -> None:
+            if _legacy_heuristic_engine_import_error is not None:
+                raise ImportError(
+                    "The optional legacy 'heuristics.engine.HeuristicEngine' dependency is not installed or failed to import. "
+                    "This engine might be required for certain functionalities. Please ensure the 'heuristics' package is correctly installed if needed."
+                ) from _legacy_heuristic_engine_import_error
+            raise ImportError(
+                "The optional legacy 'heuristics.engine.HeuristicEngine' dependency is not available."
+            )
+
+        def tag_flows(self, packets_df: pd.DataFrame) -> pd.DataFrame:
+            raise NotImplementedError(
+                "Legacy HeuristicEngine is not available due to a missing optional dependency. Cannot call tag_flows."
+            )
+
 import pandas as pd
 import yaml
 
@@ -178,3 +206,6 @@ class VectorisedHeuristicEngine:
                 "flow_cause",
             ]
         ]
+
+
+__all__ = ["VectorisedHeuristicEngine", "HeuristicEngine"]

--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -15,7 +15,7 @@ from .metrics.stats_collector import StatsCollector
 from .metrics.timeline_builder import TimelineBuilder
 from .enrich.service_guesser import guess_service
 from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
-from heuristics.engine import HeuristicEngine
+from pcap_tool.heuristics.engine import HeuristicEngine
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from .enrichment import Enricher

--- a/src/pcap_tool/pipeline_app.py
+++ b/src/pcap_tool/pipeline_app.py
@@ -13,7 +13,7 @@ from .enrichment import Enricher
 from .enrich import service_guesser
 from .analyze import ErrorSummarizer, SecurityAuditor
 from .metrics_builder import MetricsBuilder
-from heuristics.engine import HeuristicEngine
+from pcap_tool.heuristics.engine import HeuristicEngine
 from .llm_summarizer import LLMSummarizer
 from .utils import safe_int_or_default
 from .pipeline_helpers import (

--- a/src/pcap_tool/pipeline_helpers.py
+++ b/src/pcap_tool/pipeline_helpers.py
@@ -139,7 +139,7 @@ def collect_stats(records: List[PcapRecord]) -> dict[str, Any]:
 
 def build_metrics(df: pd.DataFrame, heuristics_rules: Path) -> pd.DataFrame:
     """Tag ``df`` flows using the provided heuristic rules."""
-    from heuristics.engine import HeuristicEngine
+    from pcap_tool.heuristics.engine import HeuristicEngine
 
     engine = HeuristicEngine(str(heuristics_rules))
     return engine.tag_flows(df)


### PR DESCRIPTION
## Summary
- reference heuristics engine from the pcap_tool package
- expose `HeuristicEngine` through `pcap_tool.heuristics.engine` for compatibility
- improve fallback import handling for `HeuristicEngine`

## Testing
- `flake8 src/ tests/`
- `pytest -q`