### PR TITLE
Add TLS version aggregation to metrics

### DIFF
--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -16,6 +16,7 @@ from .metrics.timeline_builder import TimelineBuilder
 from .enrich.service_guesser import guess_service
 from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
 from pcap_tool.heuristics.engine import HeuristicEngine
+from pcap_tool.heuristics.metrics import count_tls_versions
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from .enrichment import Enricher
@@ -100,6 +101,7 @@ class MetricsBuilder:
         "protocols": {},
         "top_ports": {},
         "quic_vs_tls_packets": {},
+        "tls_version_counts": {},
         "top_talkers_by_bytes": [],
         "top_talkers_by_packets": [],
         "service_overview": {},
@@ -150,6 +152,7 @@ class MetricsBuilder:
             "protocols": {},
             "top_ports": {},
             "quic_vs_tls_packets": {},
+            "tls_version_counts": {},
             "top_talkers_by_bytes": [],
             "top_talkers_by_packets": [],
             "service_overview": {},
@@ -165,6 +168,9 @@ class MetricsBuilder:
         metrics["protocols"] = sc_summary.get("protocols", {})
         metrics["top_ports"] = sc_summary.get("top_ports", {})
         metrics["quic_vs_tls_packets"] = sc_summary.get("quic_vs_tls_packets", {})
+        metrics["tls_version_counts"] = count_tls_versions(
+            packet_df_for_enrich_detail.to_dict(orient="records")
+        ) if not packet_df_for_enrich_detail.empty else {}
 
         # Flow table summaries
         df_bytes, df_pkts = self.flow_table.get_summary_df()

--- a/tests/test_metrics_tls_versions.py
+++ b/tests/test_metrics_tls_versions.py
@@ -1,0 +1,33 @@
+import pandas as pd
+from pcap_tool.metrics_builder import MetricsBuilder
+from pcap_tool.metrics.flow_table import FlowTable
+from pcap_tool.metrics.stats_collector import StatsCollector
+from pcap_tool.metrics.timeline_builder import TimelineBuilder
+from pcap_tool.analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
+from pcap_tool.enrichment import Enricher
+
+class DummyServiceGuesser:
+    def guess_service(self, *args, **kwargs):
+        return "dummy"
+
+class DummyHeuristic:
+    pass
+
+def test_metrics_builder_tls_version_counts():
+    packet_df = pd.DataFrame([
+        {"tls_effective_version": "TLS 1.2"},
+        {"tls_effective_version": "TLS 1.3"},
+    ])
+    mb = MetricsBuilder(
+        StatsCollector(),
+        FlowTable(),
+        Enricher(),
+        DummyServiceGuesser(),
+        PerformanceAnalyzer(),
+        TimelineBuilder(),
+        ErrorSummarizer(),
+        SecurityAuditor(Enricher()),
+        DummyHeuristic(),
+    )
+    metrics = mb.build_metrics(packet_df, pd.DataFrame())
+    assert metrics["tls_version_counts"] == {"TLS 1.2": 1, "TLS 1.3": 1}


### PR DESCRIPTION
## Summary
- compute TLS version totals in `MetricsBuilder` using `count_tls_versions`
- expose new `tls_version_counts` field in metrics
- test that `MetricsBuilder` returns TLS version counts

## Testing
- `flake8 src/ tests/`
- `pytest -q`