### PR TITLE
Add TLS handshake outcome analysis

### DIFF
--- a/src/pcap_tool/heuristics/dns_tls_mismatch.py
+++ b/src/pcap_tool/heuristics/dns_tls_mismatch.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import pandas as pd
 from typing import List, Tuple, Dict, Any
 
+# Maximum age in seconds for a DNS answer to be considered relevant to a TLS
+# connection when checking for mismatches.
+DNS_TLS_MAX_AGE_SECONDS = 60
+
 
 def _pick_column(df: pd.DataFrame, names: List[str]) -> str | None:
     for name in names:

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -999,7 +999,10 @@ def _parse_with_pyshark(
                 yield record_obj
                 generated_records += 1
             except AttributeError as ae: # This should be less common with _get_pyshark_layer_attribute
-                logger.warning(f"Frame {packet_count}: Attribute error processing packet details: {ae}. Packet Layers: {[l.layer_name for l in packet.layers if hasattr(l, 'layer_name')]}", exc_info=False) # exc_info=False to reduce noise if frequent
+                logger.warning(
+                    f"Frame {packet_count}: Attribute error processing packet details: {ae}. Packet Layers: {[layer.layer_name for layer in packet.layers if hasattr(layer, 'layer_name')]}",
+                    exc_info=False,
+                )  # exc_info=False to reduce noise if frequent
             except Exception as e_pkt: # Catch-all for other unexpected errors per packet
                 logger.error(f"Frame {packet_count}: Error processing packet: {e_pkt}. Skipping.", exc_info=True) # Keep exc_info for unexpected
 

--- a/src/pcap_tool/parsers/tls.py
+++ b/src/pcap_tool/parsers/tls.py
@@ -1,0 +1,107 @@
+import pandas as pd
+from typing import Any, List
+
+
+# Maximum allowed time in seconds between the first ClientHello and
+# ServerHello messages for a handshake to be considered successful.
+TLS_HANDSHAKE_TIMEOUT_SECONDS = 5
+
+
+__all__ = ["get_tls_handshake_outcome"]
+
+
+def get_tls_handshake_outcome(packets_df: pd.DataFrame) -> pd.DataFrame:
+    """Return TLS handshake outcome per flow.
+
+    Parameters
+    ----------
+    packets_df:
+        DataFrame containing packet level fields including ``timestamp``,
+        ``tls_handshake_type``, ``tls_alert_message_description``,
+        ``tcp_flags_rst`` and an orientation column (``is_source_client`` or
+        ``is_src_client``).
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with ``flow_id`` mapped the same way as
+        :func:`VectorisedHeuristicEngine._aggregate_flows` and columns
+        ``tls_handshake_ok`` (boolean), ``first_alert_time`` and
+        ``time_to_alert``.
+    """
+    if packets_df.empty:
+        return pd.DataFrame(
+            columns=["flow_id", "tls_handshake_ok", "first_alert_time", "time_to_alert"]
+        )
+
+    df = packets_df.copy()
+    orient_col = None
+    if "is_source_client" in df.columns:
+        orient_col = "is_source_client"
+    elif "is_src_client" in df.columns:
+        orient_col = "is_src_client"
+    if orient_col is None:
+        raise ValueError("is_source_client column required for TLS analysis")
+
+    cols = ["client_ip", "server_ip", "client_port", "server_port", "protocol"]
+    df["client_ip"] = df.apply(
+        lambda r: r["source_ip"] if r[orient_col] else r["destination_ip"], axis=1
+    )
+    df["server_ip"] = df.apply(
+        lambda r: r["destination_ip"] if r[orient_col] else r["source_ip"], axis=1
+    )
+    df["client_port"] = df.apply(
+        lambda r: r["source_port"] if r[orient_col] else r["destination_port"], axis=1
+    )
+    df["server_port"] = df.apply(
+        lambda r: r["destination_port"] if r[orient_col] else r["source_port"], axis=1
+    )
+    if "timestamp" not in df.columns:
+        df["timestamp"] = pd.NA
+
+    groups = df.groupby(cols)
+    index = groups.size().index
+    flow_df = pd.DataFrame(list(index), columns=cols)
+    flow_df = flow_df.reset_index(drop=True)
+    flow_df["flow_id"] = flow_df.index
+
+    client_mask = df[orient_col] == True
+    server_mask = df[orient_col] == False
+
+    ch_mask = client_mask & (df.get("tls_handshake_type") == "ClientHello")
+    sh_mask = server_mask & (df.get("tls_handshake_type") == "ServerHello")
+
+    first_ch = df[ch_mask].groupby(cols)["timestamp"].min()
+    first_sh = df[sh_mask].groupby(cols)["timestamp"].min()
+
+    alert_mask = df.get("tls_alert_message_description").notna() if "tls_alert_message_description" in df.columns else pd.Series(False, index=df.index)
+    rst_mask = df.get("tcp_flags_rst", False).fillna(False)
+    alert_mask = alert_mask | rst_mask
+    first_alert = df[alert_mask].groupby(cols)["timestamp"].min()
+
+    flow_df["first_client_hello_time"] = first_ch.reindex(index).values
+    flow_df["first_server_hello_time"] = first_sh.reindex(index).values
+    flow_df["first_alert_time"] = first_alert.reindex(index).values
+
+    flow_df["time_to_alert"] = flow_df["first_alert_time"] - flow_df["first_client_hello_time"]
+
+    handshake_ok = (
+        flow_df["first_client_hello_time"].notna()
+        & flow_df["first_server_hello_time"].notna()
+        & (
+            flow_df["first_alert_time"].isna()
+            | (flow_df["first_server_hello_time"] <= flow_df["first_alert_time"])
+        )
+        & (
+            (
+                flow_df["first_server_hello_time"]
+                - flow_df["first_client_hello_time"]
+            )
+            <= TLS_HANDSHAKE_TIMEOUT_SECONDS
+        )
+    )
+    flow_df["tls_handshake_ok"] = pd.NA
+    mask_ch = flow_df["first_client_hello_time"].notna()
+    flow_df.loc[mask_ch, "tls_handshake_ok"] = handshake_ok[mask_ch]
+
+    return flow_df[["flow_id", "tls_handshake_ok", "first_alert_time", "time_to_alert"]]

--- a/tests/test_tls_handshake.py
+++ b/tests/test_tls_handshake.py
@@ -1,0 +1,45 @@
+import pandas as pd
+import pytest
+from pcap_tool.heuristics.engine import VectorisedHeuristicEngine
+from pcap_tool.parsers.tls import get_tls_handshake_outcome
+
+
+def _pkt(ts, src, dst, sport, dport, client, hs_type=None, alert=None, rst=False):
+    return {
+        "timestamp": ts,
+        "source_ip": src,
+        "destination_ip": dst,
+        "source_port": sport,
+        "destination_port": dport,
+        "protocol": "TCP",
+        "is_source_client": client,
+        "tcp_flags_syn": False,
+        "tcp_flags_ack": False,
+        "tcp_flags_psh": False,
+        "tcp_flags_rst": rst,
+        "tls_handshake_type": hs_type,
+        "tls_alert_message_description": alert,
+    }
+
+
+def test_tls_handshake_outcome_and_blocking():
+    packets = [
+        _pkt(0.0, "1.1.1.1", "2.2.2.2", 1111, 443, True, hs_type="ClientHello"),
+        _pkt(0.1, "2.2.2.2", "1.1.1.1", 443, 1111, False, hs_type="ServerHello"),
+        _pkt(1.0, "3.3.3.3", "4.4.4.4", 2222, 443, True, hs_type="ClientHello"),
+        _pkt(1.2, "4.4.4.4", "3.3.3.3", 443, 2222, False, alert="handshake_failure"),
+    ]
+    df = pd.DataFrame(packets)
+
+    outcome = get_tls_handshake_outcome(df)
+    assert outcome.loc[0, "tls_handshake_ok"] is True
+    assert outcome.loc[1, "tls_handshake_ok"] is False
+
+    engine = VectorisedHeuristicEngine()
+    flows = engine.tag_flows(df)
+
+    fail_row = flows.loc[flows.client_ip == "3.3.3.3"].iloc[0]
+    assert fail_row.tls_handshake_ok is False
+    assert fail_row.flow_disposition == "Blocked"
+    assert fail_row.flow_cause == "TLS Handshake Failure"
+    assert fail_row.time_to_alert == pytest.approx(0.2)


### PR DESCRIPTION
## Summary
- implement `get_tls_handshake_outcome` to detect TLS handshake success/failure
- use handshake results in heuristic engine to mark blocked flows
- expose alert timing info
- fix flake8 issue in parser and dns mismatch module
- add unit test for TLS handshake logic
- define handshake timeout constant

## Testing
- `flake8 src/ tests/`
- `pytest -q`
