### PR TITLE
Add plaintext detection for HTTP CONNECT

### DIFF
--- a/src/pcap_tool/performance/__init__.py
+++ b/src/pcap_tool/performance/__init__.py
@@ -1,0 +1,1 @@
+from .plaintext_detector import count_plaintext_http_flows, count_plaintext_http_flows_df

--- a/src/pcap_tool/performance/plaintext_detector.py
+++ b/src/pcap_tool/performance/plaintext_detector.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping, Any
+
+import pandas as pd
+
+
+def _is_plain_packet(pkt: Mapping[str, Any]) -> bool:
+    """Return True if packet ``pkt`` is likely plaintext HTTP."""
+    proto = str(pkt.get("protocol") or pkt.get("proto") or "").upper()
+    method = str(pkt.get("http_request_method") or pkt.get("http_method") or "").upper()
+
+    if proto == "HTTP" and method == "CONNECT":
+        return True
+
+    if proto == "HTTP":
+        return True
+
+    port = pkt.get("destination_port") or pkt.get("dest_port")
+    try:
+        port_int = int(port) if port is not None else None
+    except (TypeError, ValueError):
+        port_int = None
+    if proto == "TCP" and port_int == 80:
+        http_method = method or str(pkt.get("http_request_method") or "").upper()
+        if http_method:
+            return True
+    return False
+
+
+def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
+    """Return number of unique flows containing plaintext HTTP packets."""
+    flows = set()
+    for pkt in records:
+        if _is_plain_packet(pkt):
+            src_ip = pkt.get("source_ip") or pkt.get("src_ip")
+            dst_ip = pkt.get("destination_ip") or pkt.get("dest_ip")
+            src_port = pkt.get("source_port") or pkt.get("src_port")
+            dst_port = pkt.get("destination_port") or pkt.get("dest_port")
+            proto = str(pkt.get("protocol") or pkt.get("proto") or "").upper()
+            flows.add((src_ip, dst_ip, src_port, dst_port, proto))
+    return len(flows)
+
+
+def count_plaintext_http_flows_df(df: pd.DataFrame) -> int:
+    """Convenience wrapper accepting a DataFrame."""
+    return count_plaintext_http_flows(df.to_dict(orient="records"))

--- a/tests/fixtures/Failure_Pcap.csv
+++ b/tests/fixtures/Failure_Pcap.csv
@@ -1,0 +1,5 @@
+frame_number,timestamp,source_ip,destination_ip,source_port,destination_port,protocol,http_request_method
+1,1.0,10.0.0.1,93.184.216.34,54321,443,HTTP,CONNECT
+2,2.0,10.0.0.1,93.184.216.34,54321,443,HTTPS/TLS,
+3,3.0,10.0.0.1,93.184.216.34,54321,443,TCP,
+4,4.0,10.0.0.2,93.184.216.34,12345,80,HTTP,GET

--- a/tests/test_plaintext_detector.py
+++ b/tests/test_plaintext_detector.py
@@ -1,0 +1,8 @@
+import pandas as pd
+from pcap_tool.performance import count_plaintext_http_flows_df
+
+
+def test_plaintext_detection_from_failure_csv():
+    df = pd.read_csv('tests/fixtures/Failure_Pcap.csv')
+    count = count_plaintext_http_flows_df(df)
+    assert count > 0


### PR DESCRIPTION
## Summary
- add plaintext detection helpers
- treat HTTP CONNECT as plaintext
- test plaintext detection using Failure_Pcap.csv fixture

## Testing
- `flake8 src/ tests/`
- `pytest -q`