### PR TITLE
Enforce timestamp for TLS handshake analysis

### DIFF
--- a/src/pcap_tool/parsers/tls.py
+++ b/src/pcap_tool/parsers/tls.py
@@ -24,6 +24,11 @@ def get_tls_handshake_outcome(packets_df: pd.DataFrame) -> pd.DataFrame:
         :func:`VectorisedHeuristicEngine._aggregate_flows` and columns
         ``tls_handshake_ok`` (boolean), ``first_alert_time`` and
         ``time_to_alert``.
+
+    Raises
+    ------
+    ValueError
+        If the orientation or ``timestamp`` columns are missing.
     """
     if packets_df.empty:
         return pd.DataFrame(
@@ -45,7 +50,7 @@ def get_tls_handshake_outcome(packets_df: pd.DataFrame) -> pd.DataFrame:
     df["client_port"] = np.where(df[orient_col], df["source_port"], df["destination_port"])
     df["server_port"] = np.where(df[orient_col], df["destination_port"], df["source_port"])
     if "timestamp" not in df.columns:
-        df["timestamp"] = pd.NA
+        raise ValueError("timestamp column required for TLS analysis")
 
     groups = df.groupby(cols)
     index = groups.size().index

--- a/tests/test_tls_handshake.py
+++ b/tests/test_tls_handshake.py
@@ -43,3 +43,13 @@ def test_tls_handshake_outcome_and_blocking():
     assert fail_row.flow_disposition == "Blocked"
     assert fail_row.flow_cause == "TLS Handshake Failure"
     assert fail_row.time_to_alert == pytest.approx(0.2)
+
+
+def test_tls_handshake_missing_timestamp_raises():
+    packets = [
+        _pkt(0.0, "1.1.1.1", "2.2.2.2", 1111, 443, True, hs_type="ClientHello"),
+        _pkt(0.1, "2.2.2.2", "1.1.1.1", 443, 1111, False, hs_type="ServerHello"),
+    ]
+    df = pd.DataFrame(packets).drop(columns=["timestamp"])
+    with pytest.raises(ValueError):
+        get_tls_handshake_outcome(df)


### PR DESCRIPTION
## Summary
- make timestamp a required column in TLS handshake analysis
- document required columns in TLS parser
- test error when timestamp column is missing

## Testing
- `flake8 src/ tests/`
- `pytest -q`