### PR TITLE
Add timing metrics to performance analyzer

### DIFF
--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -106,7 +106,13 @@ class MetricsBuilder:
         "top_talkers_by_packets": [],
         "service_overview": {},
         "error_summary": {},
-        "performance_metrics": {},
+        "performance_metrics": {
+            "tcp_rtt_ms": {},
+            "tcp_syn_rtt_ms": None,
+            "tls_time_to_alert_ms": None,
+            "tcp_retransmission_ratio_percent": 0.0,
+            "rtt_limited_data": False,
+        },
         "security_findings": {},
         "timeline_data": [],
     }

--- a/src/pcap_tool/performance/plaintext_detector.py
+++ b/src/pcap_tool/performance/plaintext_detector.py
@@ -8,14 +8,14 @@ import pandas as pd
 def _is_plain_packet(pkt: Mapping[str, Any]) -> bool:
     """Return True if packet ``pkt`` is likely plaintext HTTP."""
     proto = str(pkt.get("protocol") or pkt.get("proto") or "").upper()
-    method = str(pkt.get("http_request_method") or pkt.get("http_method") or "").upper()
+    method = str(
+        pkt.get("http_request_method") or pkt.get("http_method") or ""
+    ).upper()
 
     if proto == "HTTP" and method == "CONNECT":
-        # HTTP CONNECT is treated as plaintext due to [REASON - e.g., lack of encryption]
         return True
 
     if proto == "HTTP":
-        # Assuming all HTTP traffic is plaintext for simplicity. Refine if needed.
         return True
 
     port = pkt.get("destination_port") or pkt.get("dest_port")
@@ -24,29 +24,31 @@ def _is_plain_packet(pkt: Mapping[str, Any]) -> bool:
     except (TypeError, ValueError):
         port_int = None
     if proto == "TCP" and port_int == 80:
-        # Check for HTTP on port 80, but exclude TLS/SSL
         http_method = method or str(pkt.get("http_request_method") or "").upper()
-        if http_method and 'TLS' not in str(pkt.get("protocol") or pkt.get("proto") or "").upper():
+        if http_method and "TLS" not in str(pkt.get("protocol") or pkt.get("proto") or "").upper():
             return True
     return False
+
+
+def _get_packet_field(pkt: Mapping[str, Any], key: str) -> Any:
+    """Safely retrieve a packet field, returning ``None`` if not found."""
+    return pkt.get(key)
 
 
 def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
     """Return number of unique flows containing plaintext HTTP packets."""
     flows = set()
     for pkt in records:
-def _get_packet_field(pkt: Mapping[str, Any], key: str) -> Any:
-    """Safely retrieve a packet field, returning None if not found."""
-    return pkt.get(key)
-
-
-    for pkt in records:
         if _is_plain_packet(pkt):
             src_ip = _get_packet_field(pkt, "source_ip") or _get_packet_field(pkt, "src_ip")
             dst_ip = _get_packet_field(pkt, "destination_ip") or _get_packet_field(pkt, "dest_ip")
             src_port = _get_packet_field(pkt, "source_port") or _get_packet_field(pkt, "src_port")
             dst_port = _get_packet_field(pkt, "destination_port") or _get_packet_field(pkt, "dest_port")
-            proto = str(_get_packet_field(pkt, "protocol") or _get_packet_field(pkt, "proto") or "").upper()
+            proto = str(
+                _get_packet_field(pkt, "protocol")
+                or _get_packet_field(pkt, "proto")
+                or ""
+            ).upper()
             flows.add((src_ip, dst_ip, src_port, dst_port, proto))
     return len(flows)
 


### PR DESCRIPTION
## Summary
- track TLS alert timing and TCP SYN RTT in `PerformanceAnalyzer`
- export new fields in metrics schema
- clean up plaintext detector indentation
- test new metrics

## Testing
- `flake8 src/ tests/`
- `pytest -q`
