### PR TITLE
Add PDF report service and error summaries

### DIFF
--- a/src/pcap_tool/performance/plaintext_detector.py
+++ b/src/pcap_tool/performance/plaintext_detector.py
@@ -31,22 +31,23 @@ def _is_plain_packet(pkt: Mapping[str, Any]) -> bool:
     return False
 
 
-def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
-    """Return number of unique flows containing plaintext HTTP packets."""
-    flows = set()
-    for pkt in records:
 def _get_packet_field(pkt: Mapping[str, Any], key: str) -> Any:
-    """Safely retrieve a packet field, returning None if not found."""
+    """Safely retrieve a packet field, returning ``None`` if not found."""
     return pkt.get(key)
 
 
+def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
+    """Return number of unique flows containing plaintext HTTP packets."""
+    flows = set()
     for pkt in records:
         if _is_plain_packet(pkt):
             src_ip = _get_packet_field(pkt, "source_ip") or _get_packet_field(pkt, "src_ip")
             dst_ip = _get_packet_field(pkt, "destination_ip") or _get_packet_field(pkt, "dest_ip")
             src_port = _get_packet_field(pkt, "source_port") or _get_packet_field(pkt, "src_port")
             dst_port = _get_packet_field(pkt, "destination_port") or _get_packet_field(pkt, "dest_port")
-            proto = str(_get_packet_field(pkt, "protocol") or _get_packet_field(pkt, "proto") or "").upper()
+            proto = str(
+                _get_packet_field(pkt, "protocol") or _get_packet_field(pkt, "proto") or ""
+            ).upper()
             flows.add((src_ip, dst_ip, src_port, dst_port, proto))
     return len(flows)
 


### PR DESCRIPTION
## Summary
- extend PDF report with service overview & error summary helper functions
- include the two new summaries in `_build_elements`
- fix indentation for `count_plaintext_http_flows` helper

## Testing
- `flake8 src/ tests/`
- `pytest -q`