### PR TITLE
Add PDF report service and error summaries

### DIFF
--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -15,6 +15,55 @@ from .exceptions import ReportGenerationError
 from .metrics_builder import select_top_flows
 
 
+def _add_service_overview(elements: list, styles, overview: Dict[str, Any]) -> None:
+    """Append a bulleted service overview section."""
+    try:  # pragma: no cover - optional dependency
+        from reportlab.platypus import Paragraph, Spacer
+    except Exception:  # pragma: no cover - dependency may be missing
+        return
+
+    if not overview:
+        return
+
+    elements.append(Paragraph("Service Overview", styles["Heading2"]))
+    for service, info in overview.items():
+        if isinstance(info, dict):
+            count = info.get("flow_count", info.get("count", 0))
+        else:
+            count = info
+        elements.append(Paragraph(f"{service} - {count}", styles["Bullet"]))
+    elements.append(Spacer(1, 12))
+
+
+def _add_error_summary(elements: list, styles, summary: Dict[str, Any]) -> None:
+    """Append a bulleted error summary section."""
+    try:  # pragma: no cover - optional dependency
+        from reportlab.platypus import Paragraph, Spacer
+    except Exception:  # pragma: no cover - dependency may be missing
+        return
+
+    if not summary:
+        return
+
+    elements.append(Paragraph("Error Summary", styles["Heading2"]))
+    for err, info in summary.items():
+        if isinstance(info, dict) and "count" in info:
+            count = info.get("count", 0)
+            elements.append(Paragraph(f"{err} - {count}", styles["Bullet"]))
+        elif isinstance(info, dict):
+            for detail, data in info.items():
+                if isinstance(data, dict):
+                    count = data.get("count", 0)
+                else:
+                    count = data
+                elements.append(
+                    Paragraph(f"{err} ({detail}) - {count}", styles["Bullet"])
+                )
+        else:
+            elements.append(Paragraph(f"{err} - {info}", styles["Bullet"]))
+    elements.append(Spacer(1, 12))
+
+
 def _sparkline_chart(values: list[int]) -> bytes:
     """Return a tiny bar chart PNG for sparkline values."""
     if not values:
@@ -193,12 +242,8 @@ def _build_elements(
             elements.append(Paragraph(f"{k}: {v}", styles["Normal"]))
         elements.append(Spacer(1, 12))
 
-    errors = metrics_json.get("error_summary", {})
-    if errors:
-        elements.append(Paragraph("Error Summary", styles["Heading2"]))
-        for k, v in errors.items():
-            elements.append(Paragraph(f"{k}: {v}", styles["Normal"]))
-        elements.append(Spacer(1, 12))
+    _add_service_overview(elements, styles, metrics_json.get("service_overview", {}))
+    _add_error_summary(elements, styles, metrics_json.get("error_summary", {}))
 
     sec = metrics_json.get("security_findings", {})
     if sec:

--- a/src/pcap_tool/performance/plaintext_detector.py
+++ b/src/pcap_tool/performance/plaintext_detector.py
@@ -31,22 +31,23 @@ def _is_plain_packet(pkt: Mapping[str, Any]) -> bool:
     return False
 
 
-def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
-    """Return number of unique flows containing plaintext HTTP packets."""
-    flows = set()
-    for pkt in records:
 def _get_packet_field(pkt: Mapping[str, Any], key: str) -> Any:
-    """Safely retrieve a packet field, returning None if not found."""
+    """Safely retrieve a packet field, returning ``None`` if not found."""
     return pkt.get(key)
 
 
+def count_plaintext_http_flows(records: Iterable[Mapping[str, Any]]) -> int:
+    """Return number of unique flows containing plaintext HTTP packets."""
+    flows = set()
     for pkt in records:
         if _is_plain_packet(pkt):
             src_ip = _get_packet_field(pkt, "source_ip") or _get_packet_field(pkt, "src_ip")
             dst_ip = _get_packet_field(pkt, "destination_ip") or _get_packet_field(pkt, "dest_ip")
             src_port = _get_packet_field(pkt, "source_port") or _get_packet_field(pkt, "src_port")
             dst_port = _get_packet_field(pkt, "destination_port") or _get_packet_field(pkt, "dest_port")
-            proto = str(_get_packet_field(pkt, "protocol") or _get_packet_field(pkt, "proto") or "").upper()
+            proto = str(
+                _get_packet_field(pkt, "protocol") or _get_packet_field(pkt, "proto") or ""
+            ).upper()
             flows.add((src_ip, dst_ip, src_port, dst_port, proto))
     return len(flows)
 


### PR DESCRIPTION
## Summary
- extend PDF report with service overview & error summary helper functions
- include the two new summaries in `_build_elements`
- fix indentation for `count_plaintext_http_flows` helper
- refine bullet creation logic to handle nested error details

## Testing
- `flake8 src/ tests/`
- `pytest -q`
