### PR TITLE
Add Proxy Auth Failure sample

### DIFF
--- a/tests/fixtures/Failure_Pcap.csv
+++ b/tests/fixtures/Failure_Pcap.csv
@@ -1,5 +1,6 @@
-frame_number,timestamp,source_ip,destination_ip,source_port,destination_port,protocol,http_request_method
-1,1.0,10.0.0.1,93.184.216.34,54321,443,HTTP,CONNECT
-2,2.0,10.0.0.1,93.184.216.34,54321,443,HTTPS/TLS,
-3,3.0,10.0.0.1,93.184.216.34,54321,443,TCP,
-4,4.0,10.0.0.2,93.184.216.34,12345,80,HTTP,GET
+frame_number,timestamp,source_ip,destination_ip,source_port,destination_port,protocol,http_request_method,http_response_code
+1,1.0,10.0.0.1,93.184.216.34,54321,443,HTTP,CONNECT,
+2,2.0,10.0.0.1,93.184.216.34,54321,443,HTTPS/TLS,,
+3,3.0,10.0.0.1,93.184.216.34,54321,443,TCP,,
+4,4.0,10.0.0.2,93.184.216.34,12345,80,HTTP,GET,
+5,5.0,165.225.1.1,192.168.1.10,80,12345,HTTP,,407


### PR DESCRIPTION
## Summary
- update failure CSV to include HTTP 407 from a Zscaler IP

## Testing
- `flake8 src/ tests/`
- `pytest -q -k test_failure_capture_pipeline` *(fails: AssertionError)*