### PR TITLE
Update README with setup instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+.PHONY: setup
+
+setup:
+	python -m pip install --upgrade pip
+	pip install -e .[dev]
+	pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ These changes keep the codebase production-ready while letting you run everythin
 * tshark (will be installed by the setup script if using one, or needs manual install)
 * [Node.js & npm/yarn - if frontend setup is included]
 * [Docker - if docker-compose.dev.yml is a primary setup method]
+* Key Python packages like `pandas`, `scapy`, `pyshark` (and the optional
+  `pypcapkit` fallback).  These are managed through `requirements.txt`.
 
 ## Local Development Setup
 
@@ -121,9 +123,14 @@ These changes keep the codebase production-ready while letting you run everythin
 
 ## Running Tests
 
+Install the dependencies listed in `requirements.txt` before running the test
+suite:
+
 ```bash
+pip install -r requirements.txt
 pytest
 ```
+You can also run `make setup` to install everything needed for local testing.
 
 ### Data Columns
 


### PR DESCRIPTION
## Summary
- document required Python packages
- add instructions to install dependencies before running tests
- provide simple Makefile with `setup` target for installing deps

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: AssertionError in test_failure_capture_pipeline)*