### PR TITLE
Use legacy heuristics engine

### DIFF
--- a/src/heuristics/rules.yaml
+++ b/src/heuristics/rules.yaml
@@ -140,6 +140,12 @@ flow_disposition_rules:
       # This rule should be ordered after more specific RST rules.
     stop_processing: false # Could be client or server initiated mid-stream.
 
+  - name: "Proxy Authentication Failure (HTTP 407)"
+    output_value: "Blocked - Proxy Authentication Failed"
+    conditions:
+      - {field: "http_response_code", operator: "equals", value: 407}
+    stop_processing: true
+
 # ==============================================================================
 # Rule set for the 'traffic_type_guess' column
 # ==============================================================================

--- a/src/pcap_tool/heuristics/engine.py
+++ b/src/pcap_tool/heuristics/engine.py
@@ -13,8 +13,8 @@ _legacy_heuristic_engine_import_error: Optional[Exception] = None
 
 try:  # pragma: no cover - optional dependency
     from heuristics.engine import HeuristicEngine as _ImportedLegacyHeuristicEngine  # type: ignore
-    # Prefer the simplified vectorised engine during testing
-    _LegacyHeuristicEngine = None
+    # use the legacy engine when available
+    _LegacyHeuristicEngine = _ImportedLegacyHeuristicEngine
 except (ImportError, ModuleNotFoundError) as e:  # pragma: no cover - fallback if not available
     _legacy_heuristic_engine_import_error = e
 


### PR DESCRIPTION
## Summary
- honor heuristics.engine when present by assigning the imported engine to `_LegacyHeuristicEngine`
- add Proxy Authentication Failure rule for the legacy engine
- adjust failure capture test expectations

## Testing
- `flake8 src/ tests/`
- `pytest -q`
