### PR TITLE
Centralized configuration with Pydantic settings

### DIFF
--- a/src/pcap_tool/analyze/performance_analyzer.py
+++ b/src/pcap_tool/analyze/performance_analyzer.py
@@ -9,6 +9,7 @@ import pandas as pd
 
 from ..models import PcapRecord
 from ..utils import safe_int_or_default
+from ..core.config import settings
 
 
 class PerformanceAnalyzer:
@@ -66,7 +67,7 @@ class PerformanceAnalyzer:
                 syn_ts = syn_times.get(rev_key)
                 if syn_ts is not None:
                     diff = getattr(row, "timestamp", 0.0) - syn_ts
-                    if 0 <= diff <= 3.0:
+                    if 0 <= diff <= settings.tcp_rtt_timeout:
                         rtts.append(diff * 1000.0)
                     del syn_times[rev_key]
 

--- a/src/pcap_tool/core/config.py
+++ b/src/pcap_tool/core/config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Optional
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables or .env file."""
+
+    # Parser settings
+    default_parser: str = Field("pyshark", description="Preferred parser backend")
+    chunk_size: int = Field(10_000, description="Rows per DataFrame chunk")
+    max_workers: Optional[int] = Field(None, description="Maximum parser workers")
+
+    # Enrichment settings
+    geoip_city_db_path: Optional[str] = None
+    geoip_asn_db_path: Optional[str] = None
+    geoip_country_db_path: Optional[str] = None
+
+    # Analysis settings
+    tcp_rtt_timeout: float = Field(3.0, description="TCP handshake RTT timeout")
+    retransmission_threshold: float = Field(
+        1.0,
+        description="Retransmission ratio percentage considered degraded",
+    )
+
+    # Reporting settings
+    pdf_report_max_flows: int = Field(20, description="Top flows to include in PDF")
+
+    class Config:
+        env_prefix = "PCAP_TOOL_"
+        env_file = ".env"
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    """Return a singleton settings instance."""
+    return Settings()
+
+
+settings = get_settings()

--- a/src/pcap_tool/enrichment/__init__.py
+++ b/src/pcap_tool/enrichment/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pcap_tool.logging import get_logger
+from ..core.config import settings
 import socket
 from functools import lru_cache
 from typing import Any, Callable, Optional
@@ -31,9 +32,9 @@ class Enricher:
 
     def __init__(
         self,
-        geoip_city_db_path: Optional[str] = None,
-        geoip_asn_db_path: Optional[str] = None,
-        geoip_country_db_path: Optional[str] = None,
+        geoip_city_db_path: Optional[str] = settings.geoip_city_db_path,
+        geoip_asn_db_path: Optional[str] = settings.geoip_asn_db_path,
+        geoip_country_db_path: Optional[str] = settings.geoip_country_db_path,
     ) -> None:
         """Initialize the Enricher.
 

--- a/src/pcap_tool/metrics_builder.py
+++ b/src/pcap_tool/metrics_builder.py
@@ -17,6 +17,7 @@ from .enrich.service_guesser import guess_service
 from .analyze import PerformanceAnalyzer, ErrorSummarizer, SecurityAuditor
 from pcap_tool.heuristics.engine import HeuristicEngine
 from pcap_tool.heuristics.metrics import count_tls_versions
+from .core.config import settings
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type hints only
     from .enrichment import Enricher
@@ -256,7 +257,7 @@ class MetricsBuilder:
 
         # Top flows based on diagnostic relevance
         metrics["top_flows"] = (
-            select_top_flows(tagged_flow_df).to_dict(orient="records")
+            select_top_flows(tagged_flow_df, settings.pdf_report_max_flows).to_dict(orient="records")
             if not tagged_flow_df.empty
             else []
         )

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -11,6 +11,7 @@ from typing import (
 )
 import logging
 from pcap_tool.logging import get_logger
+from ..core.config import settings
 import pandas as pd
 from pathlib import Path
 import ipaddress
@@ -1403,10 +1404,10 @@ def _process_slice(
 
 def iter_parsed_frames(
     file_like: Path | IO[bytes],
-    chunk_size: int = 10_000,
+    chunk_size: int = settings.chunk_size,
     on_progress: Callable[[int, Optional[int]], None] | None = None,
     max_packets: int | None = None,
-    workers: int | None = None,
+    workers: int | None = settings.max_workers,
     _slice_start: int = 0,
     _slice_size: int | None = None,
 ) -> Iterator[pd.DataFrame]:
@@ -1418,10 +1419,11 @@ def iter_parsed_frames(
     file_like:
         Path to the PCAP file or a binary file-like object.
     chunk_size:
-        Number of rows per yielded ``DataFrame``. The default value of
-        ``10_000`` is a general-purpose starting point. Increase the size
-        if sufficient memory is available for better performance, or
-        decrease it if memory is constrained.
+        Number of rows per yielded ``DataFrame``. The default value comes from
+        :class:`~pcap_tool.core.config.Settings` and can be adjusted via
+        environment variables. Increase the size if sufficient memory is
+        available for better performance, or decrease it if memory is
+        constrained.
     on_progress:
         Optional callback receiving the current processed packet count and
         an estimated total packet count.
@@ -1562,10 +1564,10 @@ def iter_parsed_frames(
 
 def parse_pcap_to_df(
     file_like: Path | IO[bytes],
-    chunk_size: int = 10_000,
+    chunk_size: int = settings.chunk_size,
     on_progress: Callable[[int, Optional[int]], None] | None = None,
     max_packets: int | None = None,
-    workers: int | None = None,
+    workers: int | None = settings.max_workers,
 ) -> pd.DataFrame:
 
     """Parse ``file_like`` and return a single concatenated ``DataFrame``.
@@ -1662,8 +1664,8 @@ def parse_pcap(
     file_like,
     *,
     output_uri: str | None = None,
-    workers: int | None = None,
-    chunk_size: int = 10_000,
+    workers: int | None = settings.max_workers,
+    chunk_size: int = settings.chunk_size,
     on_progress: Callable[[int, Optional[int]], None] | None = None,
 ) -> ParsedHandle:
     """Parse ``file_like`` and return a handle to the parsed flows."""

--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -13,6 +13,7 @@ import pandas as pd
 from .chart_generator import protocol_pie_chart, top_ports_bar_chart
 from .exceptions import ReportGenerationError
 from .metrics_builder import select_top_flows
+from .core.config import settings
 
 
 def _add_service_overview(elements: list, styles: Dict[str, Any], overview: Dict[str, Any]) -> None:
@@ -157,7 +158,7 @@ def _build_elements(
         elements.append(Spacer(1, 12))
 
     if flows_df is not None and not flows_df.empty:
-        flows_df = select_top_flows(flows_df)
+        flows_df = select_top_flows(flows_df, settings.pdf_report_max_flows)
         elements.append(Paragraph("Top Flows", styles["Heading2"]))
 
         preferred_cols = [
@@ -174,7 +175,7 @@ def _build_elements(
         if not display_cols:
             display_cols = list(flows_df.columns[:8])
 
-        table_df = flows_df[display_cols].head(20).fillna("")
+        table_df = flows_df[display_cols].head(settings.pdf_report_max_flows).fillna("")
         spark_re = re.compile(r"sparkline_.*")
 
         header_map = {


### PR DESCRIPTION
## Summary
- add `Settings` singleton using pydantic-settings
- use configuration for parser chunk size and workers
- pull GeoIP database paths from settings
- make RTT timeout configurable
- limit number of flows in reports based on settings

## Testing
- `flake8 src/ tests/`
- `pytest -q`