### PR TITLE
Improve PyShark parser refactor

### DIFF
--- a/src/pcap_tool/parser/pyshark_parser.py
+++ b/src/pcap_tool/parser/pyshark_parser.py
@@ -1,3 +1,7 @@
-from ..parsers.pyshark_parser import _parse_with_pyshark, USE_PYSHARK
+from ..parsers.pyshark_parser import (
+    _parse_with_pyshark,
+    USE_PYSHARK,
+    PySharkParser,
+)
 
-__all__ = ["_parse_with_pyshark", "USE_PYSHARK"]
+__all__ = ["_parse_with_pyshark", "USE_PYSHARK", "PySharkParser"]

--- a/src/pcap_tool/parsers/base.py
+++ b/src/pcap_tool/parsers/base.py
@@ -24,4 +24,3 @@ class BaseParser(ABC):
         slice_size: Optional[int] = None,
     ) -> Generator[PcapRecord, None, None]:
         """Yield :class:`PcapRecord` objects for ``file_path``."""
-

--- a/src/pcap_tool/parsers/pcapkit_parser.py
+++ b/src/pcap_tool/parsers/pcapkit_parser.py
@@ -237,5 +237,3 @@ def _parse_with_pcapkit(file_path: str, max_packets: Optional[int]) -> Generator
         logger.info(
             f"PCAPKit: Finished processing. Scanned {packet_count} packets, yielded {generated_records} records."
         )
-
-

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -17,6 +17,7 @@ from ..core.constants import (
     ZPA_SYNTHETIC_IP_RANGE,
 )
 from ..models import PcapRecord
+from functools import wraps
 from .base import BaseParser
 from .utils import _safe_int, _safe_str_to_bool
 
@@ -180,13 +181,302 @@ def _heuristic_tcp_flags(key: tuple[str, int, str, int], seq: Optional[int], ack
     return flags
 
 
-class PysharkParser(BaseParser):
-    """Parser implementation using ``pyshark``."""
+class PacketExtractor:
+    """Lightweight helper for extracting fields from a pyshark packet."""
+
+    def __init__(self, packet: Any) -> None:
+        self.packet = packet
+
+    def get(self, layer: str, attr: str, frame_number: int, *, is_flag: bool = False) -> Any:
+        if not hasattr(self.packet, layer):
+            return None
+        layer_obj = getattr(self.packet, layer)
+        return _get_pyshark_layer_attribute(layer_obj, attr, frame_number, is_flag)
+
+
+def handle_parse_errors(func):
+    """Decorator to log and re-raise errors during parsing."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            yield from func(*args, **kwargs)
+        except pyshark.capture.capture.TSharkCrashException as exc:  # pragma: no cover - runtime protection
+            logger.error("TShark crashed: %s", exc)
+            raise RuntimeError("TShark crashed during parsing") from exc
+        except (FileNotFoundError, pyshark.tshark.tshark.TSharkNotFoundException) as exc:  # pragma: no cover - runtime protection
+            logger.error("File or TShark error: %s", exc)
+            raise
+        except Exception as exc:  # pragma: no cover - runtime protection
+            logger.error("Error parsing pcap: %s", exc, exc_info=True)
+            raise
+
+    return wrapper
+
+
+class PySharkParser(BaseParser):
+    """Parser implementation using :mod:`pyshark` with helper methods."""
+
+    def __init__(self) -> None:
+        self.flow_orientation: dict[Any, tuple[str | None, int | None]] = {}
+        self.tcp_syn_times: dict[tuple[str, int, str, int, str], float] = {}
+        self.tcp_rtt_samples: defaultdict[tuple[str, int, str, int, str], list[float]] = defaultdict(list)
 
     @classmethod
     def validate(cls) -> bool:  # pragma: no cover - simple availability check
         return USE_PYSHARK
 
+    def _create_capture(
+        self,
+        file_path: str,
+        *,
+        start: int = 0,
+        slice_size: Optional[int] = None,
+    ) -> "pyshark.FileCapture":
+        """Create and return a configured ``pyshark.FileCapture``."""
+
+        display_filter = None
+        if start or slice_size:
+            end = start + (slice_size or 0)
+            if slice_size is not None:
+                display_filter = f"frame.number>={start + 1} && frame.number<={end}"
+            else:
+                display_filter = f"frame.number>={start + 1}"
+
+        logger.debug("PyShark display_filter set to: %s", display_filter)
+
+        cap = pyshark.FileCapture(
+            file_path,
+            use_json=False,
+            include_raw=False,
+            keep_packets=False,
+            display_filter=display_filter,
+            custom_parameters=[
+                "-o",
+                "tls.desegment_ssl_records:TRUE",
+                "-o",
+                "tls.desegment_ssl_application_data:TRUE",
+            ],
+        )
+        try:
+            cap.load_packets(timeout=5)
+        except pyshark.capture.capture.TSharkCrashException as exc:
+            logger.error("TShark crashed while loading packets: %s", exc)
+            raise RuntimeError("TShark crashed during capture load") from exc
+        except (FileNotFoundError, pyshark.tshark.tshark.TSharkNotFoundException) as exc:
+            logger.error("Error loading capture: %s", exc)
+            raise
+        except Exception:
+            logger.exception("Failed to load packets from %s", file_path)
+            raise
+        return cap
+
+    def _packet_to_record(self, packet: Any) -> PcapRecord:
+        """Convert a ``pyshark`` packet to :class:`PcapRecord`."""
+
+        ts = float(packet.sniff_timestamp)
+        frame_number = _safe_int(packet.number) or 0
+        record = PcapRecord(frame_number=frame_number, timestamp=ts, raw_packet_summary=str(getattr(packet, "highest_layer", "")))
+        extractor = PacketExtractor(packet)
+        self._extract_layer_data(extractor, record)
+        self._extract_tcp_data(extractor, record)
+        self._extract_tls_data(extractor, record)
+        self._extract_dns_data(extractor, record)
+        self._extract_http_data(extractor, record)
+        return record
+
+    def _extract_layer_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Populate L2/L3/L4 fields on ``record``."""
+
+        record.packet_length = _safe_int(getattr(ext.packet, "length", None))
+
+        record.source_mac = ext.get("eth", "src", record.frame_number)
+        record.destination_mac = ext.get("eth", "dst", record.frame_number)
+
+        if hasattr(ext.packet, "ip"):
+            record.protocol_l3 = "IPv4"
+            record.source_ip = ext.get("ip", "src", record.frame_number)
+            record.destination_ip = ext.get("ip", "dst", record.frame_number)
+            record.ip_ttl = _safe_int(ext.get("ip", "ttl", record.frame_number))
+            record.ip_flags_df = ext.get("ip", "flags_df", record.frame_number, is_flag=True)
+            proto = _safe_int(ext.get("ip", "proto", record.frame_number))
+            record.protocol = {1: "ICMP", 6: "TCP", 17: "UDP", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
+        elif hasattr(ext.packet, "ipv6"):
+            record.protocol_l3 = "IPv6"
+            record.source_ip = ext.get("ipv6", "src", record.frame_number)
+            record.destination_ip = ext.get("ipv6", "dst", record.frame_number)
+            record.ip_ttl = _safe_int(ext.get("ipv6", "hlim", record.frame_number))
+            proto = _safe_int(ext.get("ipv6", "nxt", record.frame_number))
+            record.protocol = {6: "TCP", 17: "UDP", 58: "ICMPv6", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
+        elif hasattr(ext.packet, "arp"):
+            record.protocol_l3 = "ARP"
+            record.arp_opcode = _safe_int(ext.get("arp", "opcode", record.frame_number))
+            record.arp_sender_mac = ext.get("arp", "src_hw_mac", record.frame_number)
+            record.arp_sender_ip = ext.get("arp", "src_proto_ipv4", record.frame_number)
+            record.arp_target_mac = ext.get("arp", "dst_hw_mac", record.frame_number)
+            record.arp_target_ip = ext.get("arp", "dst_proto_ipv4", record.frame_number)
+
+    def _extract_tcp_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Populate TCP-related fields on ``record``."""
+
+        if record.protocol != "TCP" or not hasattr(ext.packet, "tcp"):
+            if record.protocol == "UDP" and record.destination_port is None:
+                record.source_port = _safe_int(ext.get("udp", "srcport", record.frame_number))
+                record.destination_port = _safe_int(ext.get("udp", "dstport", record.frame_number))
+                if record.destination_port == 443:
+                    record.is_quic = bool(hasattr(ext.packet, "quic"))
+            return
+
+        record.source_port = _safe_int(ext.get("tcp", "srcport", record.frame_number))
+        record.destination_port = _safe_int(ext.get("tcp", "dstport", record.frame_number))
+        record.tcp_flags_syn = ext.get("tcp", "flags_syn", record.frame_number, is_flag=True)
+        record.tcp_flags_ack = ext.get("tcp", "flags_ack", record.frame_number, is_flag=True)
+        record.tcp_flags_fin = ext.get("tcp", "flags_fin", record.frame_number, is_flag=True)
+        record.tcp_flags_rst = ext.get("tcp", "flags_rst", record.frame_number, is_flag=True)
+        record.tcp_flags_psh = ext.get("tcp", "flags_push", record.frame_number, is_flag=True)
+        record.tcp_flags_urg = ext.get("tcp", "flags_urg", record.frame_number, is_flag=True)
+        record.tcp_sequence_number = _safe_int(ext.get("tcp", "seq", record.frame_number))
+        record.tcp_acknowledgment_number = _safe_int(ext.get("tcp", "ack", record.frame_number))
+        win_val = ext.get("tcp", "window_size_value", record.frame_number)
+        if win_val is None:
+            win_val = ext.get("tcp", "window_size", record.frame_number)
+        record.tcp_window_size = _safe_int(win_val)
+        record.tcp_stream_index = _safe_int(ext.get("tcp", "stream", record.frame_number))
+
+        mss_val = ext.get("tcp", "options_mss_val", record.frame_number)
+        if mss_val is None:
+            mss_val = ext.get("tcp", "mss_val", record.frame_number)
+        if mss_val is not None:
+            record.tcp_options_mss = _safe_int(mss_val)
+
+        sack_perm = ext.get("tcp", "options_sack_permit", record.frame_number)
+        if sack_perm is None:
+            sack_perm = ext.get("tcp", "sack_perm", record.frame_number)
+        if sack_perm is not None:
+            record.tcp_options_sack_permitted = _safe_str_to_bool(sack_perm)
+
+        wscale_val = ext.get("tcp", "options_wscale_val", record.frame_number)
+        if wscale_val is None:
+            wscale_val = ext.get("tcp", "window_scale_multiplier", record.frame_number)
+        if wscale_val is not None:
+            record.tcp_options_window_scale = _safe_int(wscale_val)
+
+        flow_key = _flow_history_key(record.source_ip, record.source_port, record.destination_ip, record.destination_port)
+        orient_key = record.tcp_stream_index if record.tcp_stream_index is not None else flow_key
+        orient = self.flow_orientation.get(orient_key)
+        if orient is None and record.tcp_flags_syn and not record.tcp_flags_ack:
+            orient = (record.source_ip, record.source_port)
+            self.flow_orientation[orient_key] = orient
+        if orient is not None:
+            record.is_src_client = record.source_ip == orient[0] and record.source_port == orient[1]
+
+        if record.tcp_flags_syn and not record.tcp_flags_ack:
+            rtt_key = (
+                record.source_ip or "",
+                record.source_port or -1,
+                record.destination_ip or "",
+                record.destination_port or -1,
+                "TCP",
+            )
+            self.tcp_syn_times[rtt_key] = record.timestamp
+        elif record.tcp_flags_syn and record.tcp_flags_ack:
+            rtt_key_rev = (
+                record.destination_ip or "",
+                record.destination_port or -1,
+                record.source_ip or "",
+                record.source_port or -1,
+                "TCP",
+            )
+            syn_ts = self.tcp_syn_times.pop(rtt_key_rev, None)
+            if syn_ts is not None:
+                record.tcp_rtt_ms = (record.timestamp - syn_ts) * 1000.0
+                self.tcp_rtt_samples[rtt_key_rev].append(record.tcp_rtt_ms)
+
+    def _extract_tls_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Extract TLS-related metadata."""
+
+        if not hasattr(ext.packet, "tls"):
+            return
+
+        record.sni = _extract_sni_pyshark(ext.packet)
+        record.tls_record_version = TLS_VERSION_MAP.get(
+            _safe_int(ext.get("tls", "record_version", record.frame_number)),
+            ext.get("tls", "record_version", record.frame_number),
+        )
+
+        hs_type = ext.get("tls", "handshake_type", record.frame_number)
+        if hs_type is not None:
+            record.tls_handshake_type = TLS_HANDSHAKE_TYPE_MAP.get(_safe_int(hs_type), str(hs_type))
+
+        hs_ver = ext.get("tls", "handshake_version", record.frame_number)
+        if hs_ver is not None:
+            record.tls_handshake_version = TLS_VERSION_MAP.get(_safe_int(hs_ver), str(hs_ver))
+
+        record.tls_effective_version = record.tls_handshake_version or record.tls_record_version
+
+        if ext.get("tls", "record_content_type", record.frame_number) == "21":
+            alert_level = ext.get("tls", "alert_message_level", record.frame_number)
+            alert_desc = ext.get("tls", "alert_message_desc", record.frame_number)
+            if alert_level is not None:
+                record.tls_alert_level = TLS_ALERT_LEVEL_MAP.get(_safe_int(alert_level), str(alert_level))
+            if alert_desc is not None:
+                record.tls_alert_message_description = TLS_ALERT_DESCRIPTION_MAP.get(
+                    _safe_int(alert_desc), str(alert_desc)
+                )
+
+    def _extract_dns_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Extract DNS fields."""
+
+        if not hasattr(ext.packet, "dns"):
+            return
+
+        record.dns_query_name = ext.get("dns", "qry_name", record.frame_number)
+        qry_type = ext.get("dns", "qry_type", record.frame_number)
+        if qry_type is not None:
+            record.dns_query_type = DNS_QUERY_TYPE_MAP.get(_safe_int(qry_type), str(qry_type))
+
+        if ext.get("dns", "flags_response", record.frame_number, is_flag=True):
+            rcode = ext.get("dns", "flags_rcode", record.frame_number)
+            if rcode is not None:
+                record.dns_response_code = DNS_RCODE_MAP.get(_safe_int(rcode), str(rcode))
+
+            addrs = []
+            for field in ["a", "aaaa"]:
+                if hasattr(ext.packet.dns, field):
+                    val = getattr(ext.packet.dns, field)
+                    if isinstance(val, list):
+                        addrs.extend(str(v.show) if hasattr(v, "show") else str(v) for v in val)
+                    elif isinstance(val, str):
+                        addrs.extend([a.strip() for a in val.split(",") if a.strip()])
+                    else:
+                        addrs.append(str(val.show) if hasattr(val, "show") else str(val))
+            if addrs:
+                record.dns_response_addresses = addrs
+
+            if hasattr(ext.packet.dns, "cname"):
+                cname_val = getattr(ext.packet.dns, "cname")
+                record.dns_response_cname_target = (
+                    str(cname_val[0].show) if isinstance(cname_val, list) else str(cname_val.show)
+                ) if hasattr(cname_val, "show") else str(cname_val)
+
+    def _extract_http_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Extract HTTP request/response fields."""
+
+        if not hasattr(ext.packet, "http"):
+            return
+
+        if hasattr(ext.packet.http, "request_method"):
+            record.http_request_method = ext.get("http", "request_method", record.frame_number)
+            record.http_request_uri = ext.get("http", "request_uri", record.frame_number)
+            record.http_request_host_header = ext.get("http", "host", record.frame_number)
+            record.http_x_forwarded_for_header = ext.get("http", "x_forwarded_for", record.frame_number)
+        else:
+            code = ext.get("http", "response_code", record.frame_number)
+            if code is not None:
+                record.http_response_code = _safe_int(code)
+            record.http_response_location_header = ext.get("http", "location", record.frame_number)
+
+    @handle_parse_errors
     def parse(
         self,
         file_path: str,
@@ -195,14 +485,27 @@ class PysharkParser(BaseParser):
         start: int = 0,
         slice_size: Optional[int] = None,
     ) -> Generator[PcapRecord, None, None]:
-        return _parse_with_pyshark(
-            file_path,
-            max_packets,
-            start=start,
-            slice_size=slice_size,
-        )
+        """Yield :class:`PcapRecord` objects for ``file_path``."""
+
+        cap = self._create_capture(file_path, start=start, slice_size=slice_size)
+        generated = 0
+        try:
+            for pkt in cap:
+                yield self._packet_to_record(pkt)
+                generated += 1
+                if max_packets is not None and generated >= max_packets:
+                    break
+        finally:
+            cap.close()
 
 
+# Backwards compatibility: old name with lowercase "s"
+PysharkParser = PySharkParser
+
+
+# Legacy parser generator retained for external callers relying on the old API.
+# It mirrors the original monolithic implementation and will be removed in a
+# future major release.
 def _parse_with_pyshark(
     file_path: str,
     max_packets: Optional[int],


### PR DESCRIPTION
## Summary
- refine parse error handling
- handle fallbacks for TCP options when extracting packet data
- use helper methods in `PySharkParser.parse`
- expose `PySharkParser` from compatibility module
- fix lint warnings

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: test_detect_packet_error_dataframe, test_parser, test_tcp_analysis_flags)*
