### PR TITLE
Refactor PyShark parser logic

### DIFF
--- a/src/pcap_tool/parser/pyshark_parser.py
+++ b/src/pcap_tool/parser/pyshark_parser.py
@@ -1,3 +1,24 @@
-from ..parsers.pyshark_parser import _parse_with_pyshark, USE_PYSHARK
+from typing import Generator, Optional
+
+from ..parsers.pyshark_parser import PySharkParser, USE_PYSHARK
+
+
+def _parse_with_pyshark(
+    file_path: str,
+    max_packets: Optional[int],
+    *,
+    start: int = 0,
+    slice_size: Optional[int] = None,
+) -> Generator:
+    """Backwards compatible wrapper around :class:`PySharkParser`."""
+
+    parser = PySharkParser()
+    yield from parser.parse(
+        file_path,
+        max_packets,
+        start=start,
+        slice_size=slice_size,
+    )
+
 
 __all__ = ["_parse_with_pyshark", "USE_PYSHARK"]

--- a/src/pcap_tool/parsers/base.py
+++ b/src/pcap_tool/parsers/base.py
@@ -24,4 +24,3 @@ class BaseParser(ABC):
         slice_size: Optional[int] = None,
     ) -> Generator[PcapRecord, None, None]:
         """Yield :class:`PcapRecord` objects for ``file_path``."""
-

--- a/src/pcap_tool/parsers/pcapkit_parser.py
+++ b/src/pcap_tool/parsers/pcapkit_parser.py
@@ -237,5 +237,3 @@ def _parse_with_pcapkit(file_path: str, max_packets: Optional[int]) -> Generator
         logger.info(
             f"PCAPKit: Finished processing. Scanned {packet_count} packets, yielded {generated_records} records."
         )
-
-

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -292,6 +292,7 @@ class PySharkParser(BaseParser):
         self._extract_tls_data(extractor, record)
         self._extract_dns_data(extractor, record)
         self._extract_http_data(extractor, record)
+        self._extract_misc_data(extractor, record)
         return record
 
     def _extract_layer_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
@@ -342,6 +343,8 @@ class PySharkParser(BaseParser):
         record.tcp_flags_ack = ext.get("tcp", "flags_ack", record.frame_number, is_flag=True)
         record.tcp_flags_fin = ext.get("tcp", "flags_fin", record.frame_number, is_flag=True)
         record.tcp_flags_rst = ext.get("tcp", "flags_rst", record.frame_number, is_flag=True)
+        if record.tcp_flags_rst is None:
+            record.tcp_flags_rst = ext.get("tcp", "flags_reset", record.frame_number, is_flag=True)
         record.tcp_flags_psh = ext.get("tcp", "flags_push", record.frame_number, is_flag=True)
         record.tcp_flags_urg = ext.get("tcp", "flags_urg", record.frame_number, is_flag=True)
         record.tcp_sequence_number = _safe_int(ext.get("tcp", "seq", record.frame_number))
@@ -350,7 +353,7 @@ class PySharkParser(BaseParser):
         record.tcp_stream_index = _safe_int(ext.get("tcp", "stream", record.frame_number))
 
         flow_key = (record.source_ip, record.source_port, record.destination_ip, record.destination_port)
-        orient_key = record.tcp_stream_index or flow_key
+        orient_key = record.tcp_stream_index if record.tcp_stream_index is not None else flow_key
         orient = self.flow_orientation.get(orient_key)
         if orient is None and record.tcp_flags_syn and not record.tcp_flags_ack:
             orient = (record.source_ip, record.source_port)
@@ -545,6 +548,41 @@ class PySharkParser(BaseParser):
                 record.http_response_code = _safe_int(code)
             record.http_response_location_header = ext.get("http", "location", record.frame_number)
 
+    def _extract_misc_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
+        """Extract miscellaneous fields like ICMP details and Zscaler flags."""
+
+        icmp_layer = None
+        if record.protocol == "ICMP" and hasattr(ext.packet, "icmp"):
+            icmp_layer = ext.packet.icmp
+        elif record.protocol == "ICMPv6" and hasattr(ext.packet, "icmpv6"):
+            icmp_layer = ext.packet.icmpv6
+
+        if icmp_layer is not None:
+            record.icmp_type = _safe_int(_get_pyshark_layer_attribute(icmp_layer, "type", record.frame_number))
+            record.icmp_code = _safe_int(_get_pyshark_layer_attribute(icmp_layer, "code", record.frame_number))
+
+            frag_needed_v4 = record.protocol == "ICMP" and record.icmp_type == 3 and record.icmp_code == 4
+            pkt_too_big_v6 = record.protocol == "ICMPv6" and record.icmp_type == 2 and record.icmp_code == 0
+            if frag_needed_v4 or pkt_too_big_v6:
+                mtu_str = _get_pyshark_layer_attribute(icmp_layer, "mtu", record.frame_number)
+                if mtu_str is None and frag_needed_v4:
+                    mtu_str = _get_pyshark_layer_attribute(icmp_layer, "nexthopmtu", record.frame_number)
+                if mtu_str is not None:
+                    record.icmp_fragmentation_needed_original_mtu = _safe_int(mtu_str)
+
+        if record.source_ip is None and record.destination_ip is None:
+            record.is_zscaler_ip = None
+            record.is_zpa_synthetic_ip = None
+        else:
+            record.is_zscaler_ip = (
+                _check_ip_in_ranges(record.source_ip, ZSCALER_EXAMPLE_IP_RANGES)
+                or _check_ip_in_ranges(record.destination_ip, ZSCALER_EXAMPLE_IP_RANGES)
+            )
+            record.is_zpa_synthetic_ip = (
+                _check_ip_in_ranges(record.source_ip, [ZPA_SYNTHETIC_IP_RANGE])
+                or _check_ip_in_ranges(record.destination_ip, [ZPA_SYNTHETIC_IP_RANGE])
+            )
+
     @handle_parse_errors
     def parse(
         self,
@@ -555,792 +593,42 @@ class PySharkParser(BaseParser):
         slice_size: Optional[int] = None,
     ) -> Generator[PcapRecord, None, None]:
         """Yield :class:`PcapRecord` objects for ``file_path``."""
+        # Reset state for each parse invocation to avoid cross-file carryover
+        self.flow_orientation.clear()
+        self.tcp_syn_times.clear()
+        self.tcp_rtt_samples.clear()
 
-        # The detailed parsing logic is implemented in ``_parse_with_pyshark``.
-        # This method delegates to that generator to preserve existing
-        # behaviour while exposing the class-based API.
-        yield from _parse_with_pyshark(
+        logger.info(f"Starting PCAP parsing with PyShark for: {file_path}")
+
+        cap = self._create_capture(
             file_path,
-            max_packets,
             start=start,
             slice_size=slice_size,
+            load_timeout=self.load_timeout,
         )
+
+        generated_records = 0
+        try:
+            for packet in cap:
+                if max_packets is not None and generated_records >= max_packets:
+                    logger.info(
+                        f"PySharkParser: Reached max_packets limit of {max_packets}."
+                    )
+                    break
+
+                try:
+                    record = self._packet_to_record(packet)
+                    yield record
+                    generated_records += 1
+                except Exception as exc:  # pragma: no cover - runtime protection
+                    logger.error("Error processing packet: %s", exc, exc_info=True)
+        finally:
+            if cap:
+                cap.close()
+            logger.info(
+                f"PySharkParser: Finished processing. Yielded {generated_records} records."
+            )
 
 
 # Backwards compatibility: old name with lowercase "s"
 PysharkParser = PySharkParser
-
-
-def _parse_with_pyshark(
-    file_path: str,
-    max_packets: Optional[int],
-    *,
-    start: int = 0,
-    slice_size: Optional[int] = None,
-) -> Generator[PcapRecord, None, None]:
-    logger.info(f"Starting PCAP parsing with PyShark for: {file_path}")
-    generated_records = 0
-    cap = None
-    flow_orientation: dict[Any, tuple[str | None, int | None]] = {}
-    tcp_syn_times: dict[tuple[str, int, str, int, str], float] = {}
-    tcp_rtt_samples: defaultdict[tuple[str, int, str, int, str], list[float]] = defaultdict(list)
-    try:
-        display_filter = None
-        if start or slice_size:
-            end = start + (slice_size or 0)
-            if slice_size is not None:
-                display_filter = f"frame.number>={start + 1} && frame.number<={end}"
-            else:
-                display_filter = f"frame.number>={start + 1}"
-        logger.debug("PyShark display_filter set to: %s", display_filter)
-        cap = pyshark.FileCapture(
-            file_path,
-            use_json=False,
-            include_raw=False,
-            keep_packets=False,
-            display_filter=display_filter,
-            custom_parameters=[
-                "-o",
-                "tls.desegment_ssl_records:TRUE",
-                "-o",
-                "tls.desegment_ssl_application_data:TRUE",
-            ],
-        )
-        try:
-            cap.load_packets(timeout=5)
-            logger.info(
-                f"PyShark capture loaded. Number of packets initially found by PyShark: {len(cap)}"
-            )
-            if len(cap) == 0:
-                logger.warning(
-                    f"PyShark found 0 packets in {file_path}. Check file and filters."
-                )
-        except Exception as e_load:
-            logger.error(
-                f"Error during PyShark cap.load_packets() or initial packet count: {e_load}",
-                exc_info=True,
-            )
-    except pyshark.tshark.tshark.TSharkNotFoundException as e_tshark:
-        logger.error(f"PyShark TSharkNotFoundException: {e_tshark}. Ensure TShark is installed and in PATH.")
-        raise RuntimeError(f"PyShark critical error: TShark not found.") from e_tshark
-    except Exception as e_init:
-        logger.error(f"PyShark error opening/initializing pcap file {file_path}: {e_init}")
-        raise RuntimeError(f"PyShark failed to open or initialize {file_path}.") from e_init
-
-    def _extract_certificate_metadata(pkt) -> dict:
-        """Return TLS certificate details from ``pkt`` if present."""
-        if not hasattr(pkt, "tls"):
-            return {}
-        tls_obj = pkt.tls
-        cert = getattr(tls_obj, "handshake_certificate", None)
-        if cert is None:
-            cert = getattr(tls_obj, "handshake__certificate", None)
-        if cert is None:
-            return {}
-        leaf = cert[0] if isinstance(cert, list) else cert
-        meta: dict[str, Any] = {}
-        meta["tls_cert_subject_cn"] = getattr(leaf, "x509sat_commonName", None)
-        meta["tls_cert_san_dns"] = getattr(leaf, "get_multiple_fields", lambda *_: None)("x509sat_dnsName")
-        meta["tls_cert_san_ip"] = getattr(leaf, "get_multiple_fields", lambda *_: None)("x509sat_ipAddress")
-        meta["tls_cert_issuer_cn"] = getattr(leaf, "x509sat_issuer_commonName", None)
-        meta["tls_cert_serial_number"] = getattr(leaf, "x509af_serial_number", None)
-        nb = getattr(leaf, "x509af_validity_not_before", None)
-        na = getattr(leaf, "x509af_validity_not_after", None)
-        if nb:
-            try:
-                meta["tls_cert_not_before"] = datetime.strptime(str(nb), "%Y-%m-%d %H:%M:%S")
-            except Exception:
-                meta["tls_cert_not_before"] = None
-        if na:
-            try:
-                meta["tls_cert_not_after"] = datetime.strptime(str(na), "%Y-%m-%d %H:%M:%S")
-            except Exception:
-                meta["tls_cert_not_after"] = None
-        meta["tls_cert_sig_alg"] = getattr(leaf, "x509af_signature_algo", None)
-        key_len = getattr(leaf, "x509af_public_key_length", None)
-        if key_len is not None:
-            meta["tls_cert_key_length"] = _safe_int(key_len)
-        subj_cn = meta.get("tls_cert_subject_cn")
-        issuer_cn = meta.get("tls_cert_issuer_cn")
-        if subj_cn is not None and issuer_cn is not None:
-            meta["tls_cert_is_self_signed"] = subj_cn == issuer_cn
-        return meta
-
-    packet_count = 0
-    try:
-        for packet in cap:
-            if max_packets is not None and generated_records >= max_packets:
-                logger.info(f"PyShark: Reached max_packets limit of {max_packets}.")
-                break
-            packet_count += 1
-            try:
-                timestamp = float(packet.sniff_timestamp)
-                frame_number = _safe_int(packet.number) or 0
-
-                source_ip, destination_ip, source_port, destination_port, protocol_l4, sni = None, None, None, None, None, None
-                source_mac, destination_mac, protocol_l3, packet_length_val = None, None, None, None
-                ip_ttl, ip_flags_df_bool, ip_id_val, dscp_val = None, None, None, None # Renamed ip_flags_df to ip_flags_df_bool
-                tcp_flags_syn, tcp_flags_ack, tcp_flags_fin, tcp_flags_rst = None, None, None, None
-                tcp_flags_psh, tcp_flags_urg, tcp_flags_ece, tcp_flags_cwr = None, None, None, None
-                tcp_sequence_number, tcp_acknowledgment_number, tcp_window_size = None, None, None
-                tcp_options_mss, tcp_options_sack_permitted, tcp_options_window_scale = None, None, None
-                tcp_stream_index = None
-                is_src_client_val = None
-                tcp_analysis_retransmission_flags = []
-                tcp_analysis_duplicate_ack_flags = []
-                tcp_analysis_out_of_order_flags = []
-                tcp_analysis_window_flags = []
-                dup_ack_num_val, adv_window_val = None, None
-                tls_handshake_type_str, tls_handshake_version_str, tls_record_version_str = None, None, None
-                tls_cipher_suites_offered_list, tls_cipher_suite_selected_str = None, None
-                tls_alert_description_str, tls_alert_level_str = None, None
-                tls_effective_version_str = None
-                dns_query_name_str, dns_query_type_str, dns_response_code_str = None, None, None
-                dns_response_addresses_list, dns_response_cname_target_str = None, None
-                http_request_method_str, http_request_uri_str, http_request_host_header_str = None, None, None
-                http_response_code_int, http_response_location_header_str, http_x_forwarded_for_header_str = None, None, None
-                icmp_type_val, icmp_code_val, icmp_frag_mtu_val = None, None, None
-                arp_opcode_val, arp_sender_mac_str, arp_sender_ip_str = None, None, None
-                arp_target_mac_str, arp_target_ip_str = None, None
-                dhcp_message_type_str = None
-                gre_protocol_str, esp_spi_str = None, None
-                quic_initial_packet = None
-                is_quic_flag = None
-                is_zscaler_ip_flag, is_zpa_synthetic_ip_flag = None, None # Will become False if IPs exist and don't match
-                ssl_inspection_active_flag = None
-                zscaler_policy_block_type_str = None
-
-                raw_summary = str(packet.highest_layer) if hasattr(packet, 'highest_layer') else 'N/A'
-                if hasattr(packet, 'length'):
-                    packet_length_val = _safe_int(packet.length)
-
-                if hasattr(packet, 'eth'):
-                    eth_layer = packet.eth
-                    source_mac = _get_pyshark_layer_attribute(eth_layer, 'src', frame_number)
-                    destination_mac = _get_pyshark_layer_attribute(eth_layer, 'dst', frame_number)
-
-                ip_layer_obj = None
-                if hasattr(packet, 'ip'):
-                    protocol_l3 = "IPv4"; ip_layer_obj = packet.ip
-                    proto_num_str = _get_pyshark_layer_attribute(ip_layer_obj, 'proto', frame_number)
-                    if proto_num_str is not None:
-                        protocol_num = _safe_int(proto_num_str)
-                        if protocol_num == 1: protocol_l4 = "ICMP"
-                        elif protocol_num == 6: protocol_l4 = "TCP"
-                        elif protocol_num == 17: protocol_l4 = "UDP"
-                        elif protocol_num == 47: protocol_l4 = "GRE"
-                        elif protocol_num == 50: protocol_l4 = "ESP"
-                        else: protocol_l4 = str(protocol_num)
-                    source_ip = _get_pyshark_layer_attribute(ip_layer_obj, 'src', frame_number)
-                    destination_ip = _get_pyshark_layer_attribute(ip_layer_obj, 'dst', frame_number)
-                    ttl_str = _get_pyshark_layer_attribute(ip_layer_obj, 'ttl', frame_number)
-                    if ttl_str:
-                        ip_ttl = _safe_int(ttl_str)
-                    ip_flags_df_bool = _get_pyshark_layer_attribute(ip_layer_obj, 'flags_df', frame_number, is_flag=True)
-                    ip_id_val = _get_pyshark_layer_attribute(ip_layer_obj, 'id', frame_number)
-                    dscp_str = _get_pyshark_layer_attribute(ip_layer_obj, 'dsfield_dscp', frame_number)
-                    if dscp_str:
-                        dscp_val = _safe_int(dscp_str)
-
-                elif hasattr(packet, 'ipv6'):
-                    protocol_l3 = "IPv6"; ip_layer_obj = packet.ipv6
-                    proto_num_str = _get_pyshark_layer_attribute(ip_layer_obj, 'nxt', frame_number)
-                    if proto_num_str is not None:
-                        protocol_num = _safe_int(proto_num_str)
-                        if protocol_num == 6: protocol_l4 = "TCP"
-                        elif protocol_num == 17: protocol_l4 = "UDP"
-                        elif protocol_num == 58: protocol_l4 = "ICMPv6"
-                        elif protocol_num == 47: protocol_l4 = "GRE"
-                        elif protocol_num == 50: protocol_l4 = "ESP"
-                        else: protocol_l4 = str(protocol_num)
-                    source_ip = _get_pyshark_layer_attribute(ip_layer_obj, 'src', frame_number)
-                    destination_ip = _get_pyshark_layer_attribute(ip_layer_obj, 'dst', frame_number)
-                    hlim_str = _get_pyshark_layer_attribute(ip_layer_obj, 'hlim', frame_number)
-                    if hlim_str:
-                        ip_ttl = _safe_int(hlim_str)
-                    # IPv6 doesn't have a direct DF flag like IPv4. Fragmentation is handled by extension headers.
-                    # DSCP from tclass
-                    tclass_dscp_str = _get_pyshark_layer_attribute(ip_layer_obj, 'tclass_dscp', frame_number)
-                    if tclass_dscp_str:
-                        dscp_val = _safe_int(tclass_dscp_str)
-                    elif hasattr(ip_layer_obj, 'tclass'):
-                        tclass_hex = _get_pyshark_layer_attribute(ip_layer_obj, 'tclass', frame_number)
-                        if tclass_hex:
-                            try: dscp_val = int(str(tclass_hex), 16) >> 2
-                            except ValueError: logger.warning(f"Frame {frame_number}: Could not parse IPv6 tclass '{tclass_hex}' for DSCP.")
-
-                elif hasattr(packet, 'arp'):
-                    protocol_l3 = "ARP"
-                    arp_layer = packet.arp
-                    opcode_str = _get_pyshark_layer_attribute(arp_layer, 'opcode', frame_number)
-                    if opcode_str:
-                        arp_opcode_val = _safe_int(opcode_str)
-                    arp_sender_mac_str = _get_pyshark_layer_attribute(arp_layer, 'src_hw_mac', frame_number)
-                    arp_sender_ip_str = _get_pyshark_layer_attribute(arp_layer, 'src_proto_ipv4', frame_number)
-                    arp_target_mac_str = _get_pyshark_layer_attribute(arp_layer, 'dst_hw_mac', frame_number)
-                    arp_target_ip_str = _get_pyshark_layer_attribute(arp_layer, 'dst_proto_ipv4', frame_number)
-                else:
-                    # For non-IP/non-ARP, yield basic L2 info if available
-                    if packet_count > generated_records:
-
-
-                        yield PcapRecord(
-
-                            frame_number=frame_number,
-                            timestamp=timestamp,
-                            source_mac=source_mac,
-                            destination_mac=destination_mac,
-                            packet_length=packet_length_val,
-                            raw_packet_summary=raw_summary,
-                            tcp_rtt_ms=None,
-
-                            # Other fields default to None
-                        )
-
-                        generated_records += 1
-
-                    continue # Skip to next packet
-
-                transport_layer_obj = None
-                tcp_rtt_ms_sample = None
-                if protocol_l4 == "TCP" and hasattr(packet, 'tcp'):
-                    transport_layer_obj = packet.tcp; tcp_layer = transport_layer_obj
-                    tcp_flags_syn = _get_pyshark_layer_attribute(tcp_layer, 'flags_syn', frame_number, is_flag=True)
-                    tcp_flags_ack = _get_pyshark_layer_attribute(tcp_layer, 'flags_ack', frame_number, is_flag=True)
-                    tcp_flags_fin = _get_pyshark_layer_attribute(tcp_layer, 'flags_fin', frame_number, is_flag=True)
-                    tcp_flags_rst = _get_pyshark_layer_attribute(
-                        tcp_layer,
-                        'flags_rst',
-                        frame_number,
-                        is_flag=True,
-                    )
-                    if tcp_flags_rst is None:
-                        tcp_flags_rst = _get_pyshark_layer_attribute(
-                            tcp_layer,
-                            'flags_reset',
-                            frame_number,
-                            is_flag=True,
-                        )
-                    tcp_flags_psh = _get_pyshark_layer_attribute(tcp_layer, 'flags_push', frame_number, is_flag=True) # pyshark uses 'flags_push'
-                    tcp_flags_urg = _get_pyshark_layer_attribute(tcp_layer, 'flags_urg', frame_number, is_flag=True)
-                    tcp_flags_ece = _get_pyshark_layer_attribute(tcp_layer, 'flags_ece', frame_number, is_flag=True)
-                    tcp_flags_cwr = _get_pyshark_layer_attribute(tcp_layer, 'flags_cwr', frame_number, is_flag=True)
-
-                    seq_str = _get_pyshark_layer_attribute(tcp_layer, 'seq', frame_number)
-                    if seq_str:
-                        tcp_sequence_number = _safe_int(seq_str)
-                    ack_str = _get_pyshark_layer_attribute(tcp_layer, 'ack', frame_number)
-                    if ack_str:
-                        tcp_acknowledgment_number = _safe_int(ack_str)
-
-                    srcport_str = _get_pyshark_layer_attribute(tcp_layer, 'srcport', frame_number)
-                    if srcport_str:
-                        source_port = _safe_int(srcport_str)
-                    dstport_str = _get_pyshark_layer_attribute(tcp_layer, 'dstport', frame_number)
-                    if dstport_str:
-                        destination_port = _safe_int(dstport_str)
-
-                    win_val_str = _get_pyshark_layer_attribute(tcp_layer, 'window_size_value', frame_number)
-                    if win_val_str:
-                        tcp_window_size = _safe_int(win_val_str)
-                        adv_window_val = _safe_int(win_val_str)
-                    else: # Fallback
-                        win_str = _get_pyshark_layer_attribute(tcp_layer, 'window_size', frame_number)
-                        if win_str:
-                            tcp_window_size = _safe_int(win_str)
-                            adv_window_val = _safe_int(win_str)
-
-                    stream_str = _get_pyshark_layer_attribute(tcp_layer, 'stream', frame_number)
-                    if stream_str:
-                        tcp_stream_index = _safe_int(stream_str)
-
-                    mss_val_str = _get_pyshark_layer_attribute(tcp_layer, 'options_mss_val', frame_number)
-                    if mss_val_str:
-                        tcp_options_mss = _safe_int(mss_val_str)
-                    else: # Fallback
-                        mss_str = _get_pyshark_layer_attribute(tcp_layer, 'mss_val', frame_number)
-                        if mss_str:
-                            tcp_options_mss = _safe_int(mss_str)
-
-                    sack_perm_str = _get_pyshark_layer_attribute(tcp_layer, 'options_sack_permit', frame_number) # Note: pyshark might use 'sack_perm' or 'options_sack_permit'
-                    if sack_perm_str is not None: tcp_options_sack_permitted = _safe_str_to_bool(sack_perm_str)
-                    else: # Fallback for older PyShark or different field name
-                        sack_perm_alt_str = _get_pyshark_layer_attribute(tcp_layer, 'sack_perm', frame_number)
-                        if sack_perm_alt_str is not None: tcp_options_sack_permitted = _safe_str_to_bool(sack_perm_alt_str)
-
-                    wscale_val_str = _get_pyshark_layer_attribute(tcp_layer, 'options_wscale_val', frame_number)
-                    if wscale_val_str:
-                        tcp_options_window_scale = _safe_int(wscale_val_str)
-                    else: # Fallback for 'window_scale_multiplier' or 'ws_val'
-                        wscale_mult_str = _get_pyshark_layer_attribute(tcp_layer, 'window_scale_multiplier', frame_number)
-                        if wscale_mult_str:
-                            tcp_options_window_scale = _safe_int(wscale_mult_str)
-
-                    payload_len_str = _get_pyshark_layer_attribute(tcp_layer, 'len', frame_number)
-                    payload_len_int = _safe_int(payload_len_str) if payload_len_str else 0
-                    flow_key = _flow_history_key(source_ip, source_port, destination_ip, destination_port)
-
-                    orient_key = tcp_stream_index if tcp_stream_index is not None else flow_key
-                    orient = flow_orientation.get(orient_key)
-                    if orient is None and tcp_flags_syn and not tcp_flags_ack:
-                        orient = (source_ip, source_port)
-                        flow_orientation[orient_key] = orient
-                    if orient is not None:
-                        is_src_client_val = (
-                            source_ip == orient[0] and source_port == orient[1]
-                        )
-
-                    tcp_rtt_ms_sample = None
-                    if tcp_flags_syn and not tcp_flags_ack:
-                        rtt_key = (
-                            source_ip or "",
-                            source_port or -1,
-                            destination_ip or "",
-                            destination_port or -1,
-                            "TCP",
-                        )
-                        if rtt_key not in tcp_syn_times:
-                            if (
-                                source_ip
-                                and destination_ip
-                                and source_port is not None
-                                and destination_port is not None
-                            ):
-                                tcp_syn_times[rtt_key] = timestamp
-                            else:
-                                logger.warning(
-                                    "Could not extract SYN data for RTT calculation for packet %s in flow %s",
-                                    frame_number,
-                                    rtt_key,
-                                )
-                    elif tcp_flags_syn and tcp_flags_ack:
-                        rtt_key_rev = (
-                            destination_ip or "",
-                            destination_port or -1,
-                            source_ip or "",
-                            source_port or -1,
-                            "TCP",
-                        )
-                        syn_ts = tcp_syn_times.get(rtt_key_rev)
-                        if syn_ts is not None:
-                            tcp_rtt_ms_sample = (timestamp - syn_ts) * 1000.0
-                            tcp_rtt_samples[rtt_key_rev].append(tcp_rtt_ms_sample)
-                            del tcp_syn_times[rtt_key_rev]
-                        else:
-                            logger.debug(
-                                "No matching SYN found for SYN-ACK packet %s in flow %s",
-                                frame_number,
-                                rtt_key_rev,
-                            )
-
-                    if tcp_layer:
-                        analysis_layer = getattr(tcp_layer, 'analysis', None)
-
-                        def _get_analysis_attr(attr: str) -> Any:
-                            if analysis_layer and hasattr(analysis_layer, attr):
-                                return getattr(analysis_layer, attr)
-                            return getattr(tcp_layer, f'analysis_{attr}', None)
-
-                        if _get_analysis_attr('retransmission') is not None:
-                            tcp_analysis_retransmission_flags.append('retransmission')
-                        if _get_analysis_attr('fast_retransmission') is not None:
-                            tcp_analysis_retransmission_flags.append('fast_retransmission')
-                            if dup_ack_num_val is None:
-                                dup_ack_num_val = 3
-                        if _get_analysis_attr('spurious_retransmission') is not None:
-                            tcp_analysis_retransmission_flags.append('spurious_retransmission')
-
-                        if _get_analysis_attr('duplicate_ack') is not None:
-                            tcp_analysis_duplicate_ack_flags.append('duplicate_ack')
-                        dup_num_raw = _get_analysis_attr('duplicate_ack_num')
-                        if dup_num_raw is not None:
-                            try:
-                                dup_ack_num_val = _safe_int(dup_num_raw)
-                                if dup_ack_num_val is not None:
-                                    tcp_analysis_duplicate_ack_flags.append(f'duplicate_ack_num:{dup_ack_num_val}')
-                                else:
-                                    tcp_analysis_duplicate_ack_flags.append('duplicate_ack_num')
-                            except Exception:
-                                tcp_analysis_duplicate_ack_flags.append('duplicate_ack_num')
-
-                        if _get_analysis_attr('out_of_order') is not None:
-                            tcp_analysis_out_of_order_flags.append('out_of_order')
-                        if _get_analysis_attr('lost_segment') is not None:
-                            tcp_analysis_out_of_order_flags.append('lost_segment')
-
-                        if _get_analysis_attr('zero_window') is not None:
-                            tcp_analysis_window_flags.append('zero_window')
-                        if _get_analysis_attr('zero_window_probe') is not None:
-                            if 'zero_window' not in tcp_analysis_window_flags:
-                                tcp_analysis_window_flags.append('zero_window')
-                            tcp_analysis_window_flags.append('zero_window_probe')
-                        if _get_analysis_attr('zero_window_probe_ack') is not None:
-                            if 'zero_window' not in tcp_analysis_window_flags:
-                                tcp_analysis_window_flags.append('zero_window')
-                            tcp_analysis_window_flags.append('zero_window_probe_ack')
-                        if _get_analysis_attr('window_update') is not None:
-                            tcp_analysis_window_flags.append('window_update')
-
-                        _update_flow_history(
-                            flow_key,
-                            tcp_sequence_number,
-                            tcp_acknowledgment_number,
-                            adv_window_val,
-                            payload_len_int,
-                        )
-                    else:
-                        h_flags = _heuristic_tcp_flags(
-                            flow_key,
-                            tcp_sequence_number,
-                            tcp_acknowledgment_number,
-                            adv_window_val,
-                            payload_len_int,
-                        )
-                        if h_flags['retransmission']:
-                            tcp_analysis_retransmission_flags.append('heuristic_retransmission')
-                        if h_flags['duplicate_ack']:
-                            tcp_analysis_duplicate_ack_flags.append('heuristic_duplicate_ack')
-                        if h_flags['out_of_order']:
-                            tcp_analysis_out_of_order_flags.append('heuristic_out_of_order')
-                        if h_flags['zero_window']:
-                            tcp_analysis_window_flags.append('heuristic_zero_window')
-
-                elif protocol_l4 == "UDP" and hasattr(packet, 'udp'):
-                    transport_layer_obj = packet.udp
-
-                if transport_layer_obj:
-                    srcport_str = _get_pyshark_layer_attribute(transport_layer_obj, 'srcport', frame_number)
-                    if srcport_str:
-                        source_port = _safe_int(srcport_str)
-                    dstport_str = _get_pyshark_layer_attribute(transport_layer_obj, 'dstport', frame_number)
-                    if dstport_str:
-                        destination_port = _safe_int(dstport_str)
-
-                if protocol_l4 == "UDP" and destination_port == 443:
-                    if hasattr(packet, 'quic'):
-                        is_quic_flag = True
-                        logger.debug(f"Frame {frame_number}: UDP/443 with QUIC layer detected")
-                    else:
-                        is_quic_flag = False
-                        logger.debug(f"Frame {frame_number}: UDP/443 with no QUIC fields")
-
-                if hasattr(packet, 'tls'):
-                    sni = _extract_sni_pyshark(packet)  # SNI extraction uses its own logic
-                    tls_layer = packet.tls
-                    raw_rec_ver = _get_pyshark_layer_attribute(tls_layer, 'record_version', frame_number)
-                    if raw_rec_ver:
-                        tls_record_version_str = TLS_VERSION_MAP.get(
-                            _safe_int(raw_rec_ver), str(raw_rec_ver)
-                        )
-
-                    hs_type_val = _get_pyshark_layer_attribute(tls_layer, 'handshake_type', frame_number)
-                    if hs_type_val is not None:
-                        tls_handshake_type_str = TLS_HANDSHAKE_TYPE_MAP.get(
-                            _safe_int(hs_type_val), str(hs_type_val)
-                        )
-
-                    hs_ver_val = _get_pyshark_layer_attribute(tls_layer, 'handshake_version', frame_number)
-                    if hs_ver_val is not None:
-                        tls_handshake_version_str = TLS_VERSION_MAP.get(
-                            _safe_int(hs_ver_val), str(hs_ver_val)
-                        )
-
-                    # Supported or selected version fields vary across tshark versions
-                    supp_ver_val = None
-                    for attr in (
-                        'handshake_extensions_supported_version',
-                        'handshake_supported_version',
-                        'handshake_supported_versions',
-                    ):
-                        if hasattr(tls_layer, attr):
-                            supp_ver_val = getattr(tls_layer, attr)
-                            break
-                    if supp_ver_val is not None:
-                        if isinstance(supp_ver_val, list):
-                            ver_token = supp_ver_val[0] if supp_ver_val else None
-                        else:
-                            ver_token = supp_ver_val
-                        if ver_token is not None:
-                            tls_handshake_version_str = TLS_VERSION_MAP.get(
-                                _safe_int(ver_token), str(ver_token)
-                            )
-
-                    if tls_handshake_type_str == "ClientHello" and hasattr(tls_layer, 'handshake_ciphersuites'):
-                        raw_suites = getattr(tls_layer, 'handshake_ciphersuites')
-                        if isinstance(raw_suites, str):
-                            tls_cipher_suites_offered_list = [s.strip() for s in raw_suites.split(',')]
-                        elif isinstance(raw_suites, list):
-                            tls_cipher_suites_offered_list = [str(s.show) for s in raw_suites]
-                        else:
-                            tls_cipher_suites_offered_list = [str(raw_suites)]
-
-                    if tls_handshake_type_str == "ServerHello" and hasattr(tls_layer, 'handshake_ciphersuite'):
-                        raw_cs = getattr(tls_layer, 'handshake_ciphersuite')
-                        tls_cipher_suite_selected_str = str(raw_cs.show) if hasattr(raw_cs, 'show') else str(raw_cs)
-
-                    if tls_handshake_version_str or tls_record_version_str:
-                        tls_effective_version_str = tls_handshake_version_str or tls_record_version_str
-                    else:
-                        logger.warning(
-                            "Could not extract TLS version from packet %s", frame_number
-                        )
-
-
-                    if hasattr(tls_layer, 'record_content_type') and str(_get_pyshark_layer_attribute(tls_layer, 'record_content_type', frame_number)) == '21': # Alert
-                        alert_level_val = _get_pyshark_layer_attribute(tls_layer, 'alert_message_level', frame_number)
-                        if alert_level_val:
-                            tls_alert_level_str = TLS_ALERT_LEVEL_MAP.get(
-                                _safe_int(alert_level_val), str(alert_level_val)
-                            )
-
-                        # Try 'alert_message_description' first as it's more direct from newer tshark
-                        alert_desc_val = _get_pyshark_layer_attribute(tls_layer, 'alert_message_description', frame_number)
-                        if alert_desc_val:
-                            tls_alert_description_str = TLS_ALERT_DESCRIPTION_MAP.get(
-                                _safe_int(alert_desc_val), str(alert_desc_val)
-                            )
-                        else:  # Fallback to 'alert_message' if description not found
-                            alert_msg_val = _get_pyshark_layer_attribute(tls_layer, 'alert_message', frame_number)
-                            if alert_msg_val:
-                                tls_alert_description_str = TLS_ALERT_DESCRIPTION_MAP.get(
-                                    _safe_int(alert_msg_val), str(alert_msg_val)
-                                )  # Use same map
-                            else:
-                                tls_alert_description_str = "Unknown Alert"
-
-
-
-                if hasattr(packet, 'dns'):
-                    dns_layer = packet.dns
-                    dns_query_name_str = _get_pyshark_layer_attribute(dns_layer, 'qry_name', frame_number)
-                    qry_type_val = _get_pyshark_layer_attribute(dns_layer, 'qry_type', frame_number)
-                    if qry_type_val:
-                        dns_query_type_str = DNS_QUERY_TYPE_MAP.get(
-                            _safe_int(qry_type_val), str(qry_type_val)
-                        )
-
-                    if _get_pyshark_layer_attribute(dns_layer, 'flags_response', frame_number, is_flag=True): # Check if it's a response
-                        rcode_val = _get_pyshark_layer_attribute(dns_layer, 'flags_rcode', frame_number)
-                        if rcode_val:
-                            dns_response_code_str = DNS_RCODE_MAP.get(
-                                _safe_int(rcode_val), str(rcode_val)
-                            )
-
-                        current_response_addrs = []
-                        # Handling for 'a' and 'aaaa' which can be single or list of Field objects
-                        for addr_type_attr in ['a', 'aaaa']:
-                            if hasattr(dns_layer, addr_type_attr):
-                                val_addr_field = getattr(dns_layer, addr_type_attr)
-                                if isinstance(val_addr_field, list): # List of Field objects
-                                    for item_addr in val_addr_field:
-                                        current_response_addrs.append(str(item_addr.show) if hasattr(item_addr, 'show') else str(item_addr))
-                                elif isinstance(val_addr_field, str): # Comma-separated string
-                                     current_response_addrs.extend([addr.strip() for addr in val_addr_field.split(',') if addr.strip()])
-                                else: # Single Field object or simple string
-                                    current_response_addrs.append(str(val_addr_field.show) if hasattr(val_addr_field, 'show') else str(val_addr_field))
-                        if current_response_addrs: dns_response_addresses_list = current_response_addrs
-
-                        if hasattr(dns_layer, 'cname'):
-                            val_cname_field = getattr(dns_layer, 'cname')
-                            if isinstance(val_cname_field, list) and val_cname_field: # Take the first if it's a list
-                                dns_response_cname_target_str = str(val_cname_field[0].show) if hasattr(val_cname_field[0], 'show') else str(val_cname_field[0])
-                            else: # Single Field object or simple string
-                                dns_response_cname_target_str = str(val_cname_field.show) if hasattr(val_cname_field, 'show') else str(val_cname_field)
-
-
-                if hasattr(packet, 'http'):
-                    http_layer = packet.http
-                    if hasattr(http_layer, 'request_method'):
-                        http_request_method_str = _get_pyshark_layer_attribute(http_layer, 'request_method', frame_number)
-                        http_request_uri_str = _get_pyshark_layer_attribute(http_layer, 'request_uri', frame_number)
-                        http_request_host_header_str = _get_pyshark_layer_attribute(http_layer, 'host', frame_number)
-                        http_x_forwarded_for_header_str = _get_pyshark_layer_attribute(http_layer, 'x_forwarded_for', frame_number)
-                    elif hasattr(http_layer, 'response_code'):
-                        resp_code_str = _get_pyshark_layer_attribute(http_layer, 'response_code', frame_number)
-                        if resp_code_str:
-                            http_response_code_int = _safe_int(resp_code_str)
-                        http_response_location_header_str = _get_pyshark_layer_attribute(http_layer, 'location', frame_number)
-                    # If x_forwarded_for exists but not in request (e.g. response context, though less common)
-                    elif hasattr(http_layer, 'x_forwarded_for') and not http_request_method_str:
-                         http_x_forwarded_for_header_str = _get_pyshark_layer_attribute(http_layer, 'x_forwarded_for', frame_number)
-
-
-                icmp_layer_to_process = None
-                if protocol_l4 == "ICMP" and hasattr(packet, 'icmp'):
-                    icmp_layer_to_process = packet.icmp
-                elif protocol_l4 == "ICMPv6" and hasattr(packet, 'icmpv6'):
-                    icmp_layer_to_process = packet.icmpv6
-
-                if icmp_layer_to_process:
-                    type_str = _get_pyshark_layer_attribute(icmp_layer_to_process, 'type', frame_number)
-                    if type_str:
-                        icmp_type_val = _safe_int(type_str)
-                    code_str = _get_pyshark_layer_attribute(icmp_layer_to_process, 'code', frame_number)
-                    if code_str:
-                        icmp_code_val = _safe_int(code_str)
-
-                    # ICMP Fragmentation Needed / Packet Too Big
-                    is_frag_needed_v4 = (protocol_l4 == "ICMP" and icmp_type_val == 3 and icmp_code_val == 4)
-                    is_packet_too_big_v6 = (protocol_l4 == "ICMPv6" and icmp_type_val == 2 and icmp_code_val == 0)
-
-                    if is_frag_needed_v4 or is_packet_too_big_v6:
-                        mtu_str = _get_pyshark_layer_attribute(icmp_layer_to_process, 'mtu', frame_number) # Common field name
-                        if mtu_str:
-                            icmp_frag_mtu_val = _safe_int(mtu_str)
-                        elif is_frag_needed_v4: # Fallback for ICMPv4 specific field name
-                            nexthopmtu_str = _get_pyshark_layer_attribute(icmp_layer_to_process, 'nexthopmtu', frame_number)
-                            if nexthopmtu_str:
-                                icmp_frag_mtu_val = _safe_int(nexthopmtu_str)
-
-                # DHCP can be over 'bootp' layer in pyshark
-                dhcp_layer_source = None
-                if hasattr(packet, 'dhcp'):
-                    dhcp_layer_source = packet.dhcp
-                elif hasattr(packet, 'bootp') and hasattr(packet.bootp, 'option_dhcp_message_type'): # Check if bootp layer has DHCP options
-                    dhcp_layer_source = packet.bootp
-
-                if dhcp_layer_source:
-                    msg_type_val = _get_pyshark_layer_attribute(dhcp_layer_source, 'option_dhcp_message_type', frame_number)
-                    if msg_type_val:
-                        dhcp_message_type_str = DHCP_MESSAGE_TYPE_MAP.get(
-                            _safe_int(msg_type_val), str(msg_type_val)
-                        )
-
-
-                if protocol_l4 == "GRE" and hasattr(packet, 'gre'):
-                    gre_layer = packet.gre
-                    gre_protocol_str = _get_pyshark_layer_attribute(gre_layer, 'proto', frame_number)
-
-                if protocol_l4 == "ESP" and hasattr(packet, 'esp'):
-                    esp_layer = packet.esp
-                    esp_spi_str = _get_pyshark_layer_attribute(esp_layer, 'spi', frame_number)
-
-                if hasattr(packet, 'quic'):
-                    quic_layer = packet.quic
-                    quic_log_fields = []
-                    if hasattr(quic_layer, 'version'):
-                        quic_log_fields.append(f"version={getattr(quic_layer, 'version')}")
-                        # Check for long header type '0' (Initial)
-                        long_packet_type = _get_pyshark_layer_attribute(quic_layer, 'long_packet_type', frame_number)
-                        if long_packet_type is not None:
-                            quic_log_fields.append(f"long_packet_type={long_packet_type}")
-                            if str(long_packet_type) == '0':
-                                quic_initial_packet = True
-                        # Fallback: Check header_form '1' (Long header) if long_packet_type not definitive
-                        elif _get_pyshark_layer_attribute(quic_layer, 'header_form', frame_number, is_flag=True): # '1' is Long Header
-                            quic_initial_packet = True # Simplified, could be other long header types
-                            quic_log_fields.append('header_form=1')
-                        else:
-                            quic_initial_packet = False # It's QUIC, has version, but not clearly Initial or Long Header
-                    if quic_log_fields:
-                        logger.debug(f"Frame {frame_number}: QUIC fields {quic_log_fields}")
-
-                # Zscaler Contextual Variables
-                # These are set regardless of whether IPs were found or not; _check_ip_in_ranges handles None IPs
-                is_zscaler_ip_flag = _check_ip_in_ranges(source_ip, ZSCALER_EXAMPLE_IP_RANGES) or \
-                                     _check_ip_in_ranges(destination_ip, ZSCALER_EXAMPLE_IP_RANGES)
-                is_zpa_synthetic_ip_flag = _check_ip_in_ranges(source_ip, [ZPA_SYNTHETIC_IP_RANGE]) or \
-                                           _check_ip_in_ranges(destination_ip, [ZPA_SYNTHETIC_IP_RANGE])
-
-                # ssl_inspection_active: Still placeholder, requires cert parsing not yet implemented.
-                # zscaler_policy_block_type
-                if is_zscaler_ip_flag: # Only if one of the IPs is determined to be a Zscaler IP
-                    is_zs_source = _check_ip_in_ranges(source_ip, ZSCALER_EXAMPLE_IP_RANGES)
-                    if tcp_flags_rst and is_zs_source:
-                        zscaler_policy_block_type_str = "TCP_RST_FROM_ZSCALER"
-                    elif http_response_code_int and http_response_code_int >= 400 and is_zs_source:
-                        if http_response_code_int == 403: zscaler_policy_block_type_str = "HTTP_403_FROM_ZSCALER"
-                        elif http_response_code_int == 407: zscaler_policy_block_type_str = "HTTP_407_PROXY_AUTH_REQ_FROM_ZSCALER"
-                        else: zscaler_policy_block_type_str = f"HTTP_{http_response_code_int}_FROM_ZSCALER"
-                    elif tls_alert_level_str == "fatal" and tls_alert_description_str and is_zs_source:
-                        safe_alert_desc = "".join(c if c.isalnum() or c in ['_'] else '_' for c in tls_alert_description_str)
-                        zscaler_policy_block_type_str = f"TLS_FATAL_ALERT_FROM_ZSCALER_{safe_alert_desc[:30]}"
-
-
-                cert_meta = _extract_certificate_metadata(packet)
-
-                record_obj = PcapRecord(
-                    frame_number=frame_number, timestamp=timestamp,
-                    source_ip=source_ip, destination_ip=destination_ip,
-                    source_port=source_port, destination_port=destination_port,
-                    protocol=protocol_l4, sni=sni, raw_packet_summary=raw_summary,
-                    source_mac=source_mac, destination_mac=destination_mac,
-                    protocol_l3=protocol_l3, packet_length=packet_length_val,
-                    ip_ttl=ip_ttl, ip_flags_df=ip_flags_df_bool, ip_id=ip_id_val, dscp_value=dscp_val,
-                    tcp_flags_syn=tcp_flags_syn, tcp_flags_ack=tcp_flags_ack,
-                    tcp_flags_fin=tcp_flags_fin, tcp_flags_rst=tcp_flags_rst,
-                    tcp_flags_psh=tcp_flags_psh, tcp_flags_urg=tcp_flags_urg,
-                    tcp_flags_ece=tcp_flags_ece, tcp_flags_cwr=tcp_flags_cwr,
-                    tcp_sequence_number=tcp_sequence_number,
-                    tcp_acknowledgment_number=tcp_acknowledgment_number,
-                    tcp_window_size=tcp_window_size,
-                    tcp_options_mss=tcp_options_mss,
-                    tcp_options_sack_permitted=tcp_options_sack_permitted,
-                    tcp_options_window_scale=tcp_options_window_scale,
-                    tcp_stream_index=tcp_stream_index,
-                    is_src_client=is_src_client_val,
-                    tcp_analysis_retransmission_flags=tcp_analysis_retransmission_flags,
-                    tcp_analysis_duplicate_ack_flags=tcp_analysis_duplicate_ack_flags,
-                    tcp_analysis_out_of_order_flags=tcp_analysis_out_of_order_flags,
-                    tcp_analysis_window_flags=tcp_analysis_window_flags,
-                    dup_ack_num=dup_ack_num_val,
-                    adv_window=adv_window_val,
-                    tcp_rtt_ms=tcp_rtt_ms_sample,
-                    tls_handshake_type=tls_handshake_type_str,
-                    tls_handshake_version=tls_handshake_version_str,
-                    tls_record_version=tls_record_version_str,
-                    tls_effective_version=tls_effective_version_str,
-                    tls_cipher_suites_offered=tls_cipher_suites_offered_list,
-                    tls_cipher_suite_selected=tls_cipher_suite_selected_str,
-                    tls_alert_message_description=tls_alert_description_str,
-                    tls_alert_level=tls_alert_level_str,
-                    dns_query_name=dns_query_name_str,
-                    dns_query_type=dns_query_type_str,
-                    dns_response_code=dns_response_code_str,
-                    dns_response_addresses=dns_response_addresses_list,
-                    dns_response_cname_target=dns_response_cname_target_str,
-                    http_request_method=http_request_method_str,
-                    http_request_uri=http_request_uri_str,
-                    http_request_host_header=http_request_host_header_str,
-                    http_response_code=http_response_code_int,
-                    http_response_location_header=http_response_location_header_str,
-                    http_x_forwarded_for_header=http_x_forwarded_for_header_str,
-                    icmp_type=icmp_type_val,
-                    icmp_code=icmp_code_val,
-                    icmp_fragmentation_needed_original_mtu=icmp_frag_mtu_val,
-                    arp_opcode=arp_opcode_val,
-                    arp_sender_mac=arp_sender_mac_str,
-                    arp_sender_ip=arp_sender_ip_str,
-                    arp_target_mac=arp_target_mac_str,
-                    arp_target_ip=arp_target_ip_str,
-                    dhcp_message_type=dhcp_message_type_str,
-                    gre_protocol=gre_protocol_str,
-                    esp_spi=esp_spi_str,
-                    quic_initial_packet_present=quic_initial_packet,
-                    is_quic=is_quic_flag,
-                    is_zscaler_ip=is_zscaler_ip_flag,
-                    is_zpa_synthetic_ip=is_zpa_synthetic_ip_flag,
-                    ssl_inspection_active=ssl_inspection_active_flag,
-                    zscaler_policy_block_type=zscaler_policy_block_type_str,
-                    **cert_meta,
-                )
-                yield record_obj
-                generated_records += 1
-            except AttributeError as ae: # This should be less common with _get_pyshark_layer_attribute
-                logger.warning(
-                    f"Frame {packet_count}: Attribute error processing packet details: {ae}. Packet Layers: {[layer.layer_name for layer in packet.layers if hasattr(layer, 'layer_name')]}",
-                    exc_info=False,
-                )  # exc_info=False to reduce noise if frequent
-            except Exception as e_pkt: # Catch-all for other unexpected errors per packet
-                logger.error(f"Frame {packet_count}: Error processing packet: {e_pkt}. Skipping.", exc_info=True) # Keep exc_info for unexpected
-
-            if packet_count > 0 and packet_count % 1000 == 0 :
-                logger.info(f"PyShark: Scanned {packet_count} packets...")
-    except pyshark.capture.capture.TSharkCrashException as e_crash:
-        logger.error(f"TShark crashed while processing {file_path}: {e_crash}")
-        raise RuntimeError(f"TShark crashed, unable to process {file_path}.") from e_crash
-    except Exception as e_cap_iter:
-        logger.error(f"An error occurred during PyShark packet iteration in {file_path}: {e_cap_iter}", exc_info=True)
-    finally:
-        if cap: cap.close()
-        logger.info(f"PyShark: Finished processing. Scanned {packet_count} packets, yielded {generated_records} records.")


### PR DESCRIPTION
## Summary
- implement class-based packet parsing with ICMP and Zscaler fields
- clear parser state before each parse
- add fallback for TCP reset flag
- remove obsolete `_parse_with_pyshark` function
- provide backward-compatible wrapper

## Testing
- `flake8 src/ tests/`
- `pytest -q`