### PR TITLE
Fix ICMP processor and error decorator

### DIFF
--- a/src/pcap_tool/core/decorators.py
+++ b/src/pcap_tool/core/decorators.py
@@ -72,7 +72,6 @@ def log_performance(func):
         result = func(*args, **kwargs)
         if isinstance(result, types.GeneratorType):
             def generator():
-                nonlocal start
                 for item in result:
                     yield item
                 duration = time.perf_counter() - start
@@ -83,4 +82,3 @@ def log_performance(func):
         return result
 
     return wrapper
-

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -19,7 +19,7 @@ import os
 from math import ceil
 from concurrent.futures import ProcessPoolExecutor
 
-from ..exceptions import CorruptPcapError, ParserNotAvailable
+from ..exceptions import CorruptPcapError, ParserNotAvailable, PcapParsingError
 from ..core.decorators import handle_parse_errors, log_performance
 from ..heuristics.errors import detect_packet_error
 from ..core.constants import (

--- a/src/pcap_tool/processors/icmp_processor.py
+++ b/src/pcap_tool/processors/icmp_processor.py
@@ -40,20 +40,23 @@ class ICMPProcessor(PacketProcessor):
     def process_packet(self, extractor: "PacketExtractor", record: PcapRecord) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
         icmp_layer = None
+        layer_name = None
         if record.protocol == "ICMP" and hasattr(extractor.packet, "icmp"):
             icmp_layer = extractor.packet.icmp
+            layer_name = "icmp"
         elif record.protocol == "ICMPv6" and hasattr(extractor.packet, "icmpv6"):
             icmp_layer = extractor.packet.icmpv6
+            layer_name = "icmpv6"
 
         if icmp_layer is not None:
-            result["icmp_type"] = _safe_int(getattr(icmp_layer, "type", None))
-            result["icmp_code"] = _safe_int(getattr(icmp_layer, "code", None))
+            result["icmp_type"] = _safe_int(extractor.get(layer_name, "type", record.frame_number))
+            result["icmp_code"] = _safe_int(extractor.get(layer_name, "code", record.frame_number))
             frag_needed_v4 = record.protocol == "ICMP" and result.get("icmp_type") == 3 and result.get("icmp_code") == 4
             pkt_too_big_v6 = record.protocol == "ICMPv6" and result.get("icmp_type") == 2 and result.get("icmp_code") == 0
             if frag_needed_v4 or pkt_too_big_v6:
-                mtu_str = getattr(icmp_layer, "mtu", None)
+                mtu_str = extractor.get(layer_name, "mtu", record.frame_number)
                 if mtu_str is None and frag_needed_v4:
-                    mtu_str = getattr(icmp_layer, "nexthopmtu", None)
+                    mtu_str = extractor.get(layer_name, "nexthopmtu", record.frame_number)
                 if mtu_str is not None:
                     result["icmp_fragmentation_needed_original_mtu"] = _safe_int(mtu_str)
 

--- a/src/pcap_tool/processors/icmp_processor.py
+++ b/src/pcap_tool/processors/icmp_processor.py
@@ -39,16 +39,13 @@ class ICMPProcessor(PacketProcessor):
 
     def process_packet(self, extractor: "PacketExtractor", record: PcapRecord) -> Dict[str, Any]:
         result: Dict[str, Any] = {}
-        icmp_layer = None
         layer_name = None
         if record.protocol == "ICMP" and hasattr(extractor.packet, "icmp"):
-            icmp_layer = extractor.packet.icmp
             layer_name = "icmp"
         elif record.protocol == "ICMPv6" and hasattr(extractor.packet, "icmpv6"):
-            icmp_layer = extractor.packet.icmpv6
             layer_name = "icmpv6"
 
-        if icmp_layer is not None:
+        if layer_name is not None:
             result["icmp_type"] = _safe_int(extractor.get(layer_name, "type", record.frame_number))
             result["icmp_code"] = _safe_int(extractor.get(layer_name, "code", record.frame_number))
             frag_needed_v4 = record.protocol == "ICMP" and result.get("icmp_type") == 3 and result.get("icmp_code") == 4


### PR DESCRIPTION
## Summary
- restore return statement in `handle_parse_errors`
- simplify ICMP processor condition

## Testing
- `flake8 src/ tests/`
- `pytest -q`
