### PR TITLE
Implement optional dependency container

### DIFF
--- a/src/pcap_tool/core/constants.py
+++ b/src/pcap_tool/core/constants.py
@@ -10,9 +10,21 @@ MAGIC_PCAP_LE: bytes = b"\xd4\xc3\xb2\xa1"  # Little-endian PCAP
 MAGIC_PCAP_BE: bytes = b"\xa1\xb2\xc3\xd4"  # Big-endian PCAP
 MAGIC_PCAPNG: bytes = b"\x0a\x0d\x0d\x0a"  # PCAPNG format
 
+# Example IP ranges used in ICMP heuristics and tests
+import ipaddress
+
+ZSCALER_EXAMPLE_IP_RANGES = [
+    ipaddress.ip_network("104.129.192.0/20"),
+    ipaddress.ip_network("165.225.0.0/17"),
+]
+
+ZPA_SYNTHETIC_IP_RANGE = ipaddress.ip_network("100.64.0.0/10")
+
 
 __all__ = [
     "MAGIC_PCAP_LE",
     "MAGIC_PCAP_BE",
     "MAGIC_PCAPNG",
+    "ZSCALER_EXAMPLE_IP_RANGES",
+    "ZPA_SYNTHETIC_IP_RANGE",
 ]

--- a/src/pcap_tool/core/dependencies.py
+++ b/src/pcap_tool/core/dependencies.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Lazy dependency container for optional packages."""
+
+from importlib import import_module
+from types import ModuleType
+from typing import Dict, Optional
+
+
+class DependencyContainer:
+    """Manage optional third party dependencies."""
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, str] = {}
+        self._cache: Dict[str, Optional[ModuleType]] = {}
+
+    def register(self, name: str, module_path: str) -> None:
+        """Register an optional dependency."""
+        self._registry[name] = module_path
+
+    def _load(self, name: str) -> Optional[ModuleType]:
+        if name in self._cache:
+            return self._cache[name]
+        module_path = self._registry.get(name)
+        if module_path is None:
+            raise KeyError(f"Unknown dependency: {name}")
+        try:
+            module = import_module(module_path)
+        except Exception:  # pragma: no cover - runtime import check
+            module = None
+        self._cache[name] = module
+        return module
+
+    def get(self, name: str) -> ModuleType:
+        """Return the imported module or raise ``ImportError`` if missing."""
+        module = self._load(name)
+        if module is None:
+            mod = self._registry.get(name, name)
+            raise ImportError(
+                f"Optional dependency '{mod}' is required for this feature"
+            )
+        return module
+
+    def is_available(self, name: str) -> bool:
+        """Return ``True`` if the dependency can be imported."""
+        return self._load(name) is not None
+
+
+# Global container with known optional dependencies
+container = DependencyContainer()
+container.register("pyshark", "pyshark")
+container.register("pcapkit", "pcapkit")
+container.register("geoip2", "geoip2")
+container.register("reportlab", "reportlab")
+container.register("openai", "openai")
+
+__all__ = ["DependencyContainer", "container"]

--- a/src/pcap_tool/enrichment/__init__.py
+++ b/src/pcap_tool/enrichment/__init__.py
@@ -4,25 +4,26 @@ from __future__ import annotations
 
 from pcap_tool.logging import get_logger
 from ..core.config import settings
+from ..core.dependencies import container
 import socket
 from functools import lru_cache
 from typing import Any, Callable, Optional
 
-try:  # pragma: no cover - optional dependency
-    import geoip2.database
-    import geoip2.errors
-except Exception:  # pragma: no cover - library may not be installed
-    geoip2 = None  # type: ignore
+geoip2 = None
+Reader = None  # type: ignore
 
-    Reader = None  # type: ignore
-
+if container.is_available("geoip2"):
+    geoip2 = container.get("geoip2")  # type: ignore
+    import importlib
+    database_mod = importlib.import_module("geoip2.database")
+    errors_mod = importlib.import_module("geoip2.errors")
+    Reader = database_mod.Reader  # type: ignore
+    AddressNotFoundError = errors_mod.AddressNotFoundError  # type: ignore
+else:
     class AddressNotFoundError(Exception):
         """Fallback error if geoip2 is unavailable."""
 
         pass
-else:  # pragma: no cover - library available
-    Reader = geoip2.database.Reader  # type: ignore
-    AddressNotFoundError = geoip2.errors.AddressNotFoundError  # type: ignore
 
 logger = get_logger(__name__)
 

--- a/src/pcap_tool/llm_summarizer.py
+++ b/src/pcap_tool/llm_summarizer.py
@@ -9,7 +9,12 @@ import time
 from typing import Optional
 from pathlib import Path
 
-import openai
+from .core.dependencies import container
+
+try:  # pragma: no cover - optional dependency check
+    openai = container.get("openai")  # type: ignore
+except ImportError:  # pragma: no cover - handle missing
+    openai = None  # type: ignore
 
 logger = get_logger(__name__)
 
@@ -21,8 +26,12 @@ class LLMSummarizerError(Exception):
 class LLMSummarizer:
     """Generate plain-English summaries of metrics via GPT."""
 
-    def __init__(self, client: Optional[openai.Client] = None, model: str = "gpt-4o") -> None:
+    def __init__(self, client: Optional[object] = None, model: str = "gpt-4o") -> None:
         """Initialize the summarizer with an optional OpenAI client."""
+        if openai is None:
+            raise LLMSummarizerError(
+                "The 'openai' package is required for LLMSummarizer."
+            )
         if client is None:
             api_key = os.environ.get("OPENAI_API_KEY")
             client = openai.Client(api_key=api_key)

--- a/src/pcap_tool/parsers/pcapkit_parser.py
+++ b/src/pcap_tool/parsers/pcapkit_parser.py
@@ -6,16 +6,16 @@ from ..models import PcapRecord
 from .base import BaseParser
 from .utils import _safe_int
 from ..core.decorators import handle_parse_errors, log_performance
+from ..core.dependencies import container
 
 logger = get_logger(__name__)
 
-USE_PCAPKIT = False
-try:  # pragma: no cover - import check
-    import pcapkit
-    from pcapkit import extract as pcapkit_extract
+try:  # pragma: no cover - optional dependency check
+    pcapkit = container.get("pcapkit")
+    pcapkit_extract = pcapkit.extract
     USE_PCAPKIT = True
-except Exception:  # pragma: no cover - import check
-    pass
+except ImportError:
+    USE_PCAPKIT = False
 
 
 class PcapkitParser(BaseParser):

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -4,6 +4,7 @@ from typing import Any, Generator, Optional, TYPE_CHECKING
 
 from pcap_tool.logging import get_logger
 from ..models import PcapRecord
+from ..core.dependencies import container
 
 from ..processors import (
     PacketProcessor,
@@ -20,12 +21,12 @@ from ..core.decorators import handle_parse_errors, log_performance
 
 logger = get_logger(__name__)
 
-USE_PYSHARK = False
-try:  # pragma: no cover - import check
-    import pyshark  # type: ignore
+try:  # pragma: no cover - optional dependency check
+    pyshark = container.get("pyshark")  # type: ignore
     USE_PYSHARK = True
-except Exception:  # pragma: no cover - import check
-    pass
+except ImportError:
+    USE_PYSHARK = False
+    pyshark = None  # type: ignore
 
 if TYPE_CHECKING:  # pragma: no cover - hint for static analyzers
     from pyshark.packet.packet import Packet as PySharkPacket

--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -14,14 +14,14 @@ from .chart_generator import protocol_pie_chart, top_ports_bar_chart
 from .exceptions import ReportGenerationError
 from .metrics_builder import select_top_flows
 from .core.config import settings
+from .core.dependencies import container
 
 
 def _add_service_overview(elements: list, styles: Dict[str, Any], overview: Dict[str, Any]) -> None:
     """Append a bulleted service overview section."""
-    try:  # pragma: no cover - optional dependency
-        from reportlab.platypus import Paragraph, Spacer
-    except Exception:  # pragma: no cover - dependency may be missing
+    if not container.is_available("reportlab"):
         return
+    from reportlab.platypus import Paragraph, Spacer
 
     if not overview:
         return
@@ -38,10 +38,9 @@ def _add_service_overview(elements: list, styles: Dict[str, Any], overview: Dict
 
 def _add_error_summary(elements: list, styles, summary: Dict[str, Any]) -> None:
     """Append a bulleted error summary section."""
-    try:  # pragma: no cover - optional dependency
-        from reportlab.platypus import Paragraph, Spacer
-    except Exception:  # pragma: no cover - dependency may be missing
+    if not container.is_available("reportlab"):
         return
+    from reportlab.platypus import Paragraph, Spacer
 
     if not summary:
         return
@@ -90,6 +89,8 @@ def _build_elements(
     styles,
     summary_text: str | None = None,
 ) -> list:
+    if not container.is_available("reportlab"):
+        raise ImportError("ReportLab is required to build PDF elements")
     from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, Image
     from reportlab.lib import colors
 
@@ -295,21 +296,18 @@ def generate_pdf_report(
     ImportError
         If the ReportLab library is not installed.
     """
-    try:
-        from reportlab.lib.pagesizes import letter
-        from reportlab.lib import colors
-        from reportlab.lib.styles import getSampleStyleSheet
-        from reportlab.platypus import (
-            SimpleDocTemplate,
-            Paragraph,
-            Spacer,
-            Table,
-            TableStyle,
-        )
-    except Exception as exc:  # pragma: no cover - dependency may be missing
-        raise ImportError(
-            "ReportLab is required to generate PDF reports"
-        ) from exc
+    if not container.is_available("reportlab"):
+        raise ImportError("ReportLab is required to generate PDF reports")
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib import colors
+    from reportlab.lib.styles import getSampleStyleSheet
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Paragraph,
+        Spacer,
+        Table,
+        TableStyle,
+    )
 
     buffer = BytesIO()
     doc = SimpleDocTemplate(buffer, pagesize=letter)


### PR DESCRIPTION
## Summary
- add `DependencyContainer` to lazily load optional packages
- use container in `pyshark_parser`, `pcapkit_parser`, `pdf_report`, `llm_summarizer`, and enrichment utilities
- expose optional constants used in tests
- handle missing OpenAI and ReportLab gracefully

## Testing
- `flake8 src/ tests/`
- `pytest -q`