### PR TITLE
Improve error summarizer type hints

### DIFF
--- a/src/pcap_tool/analysis/security/security_auditor.py
+++ b/src/pcap_tool/analysis/security/security_auditor.py
@@ -8,7 +8,7 @@ from ...utils import coalesce
 from ...core.decorators import handle_analysis_errors, log_performance
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-from ...enrichment import Enricher
+    from ...enrichment import Enricher
 
 
 class SecurityAuditor:


### PR DESCRIPTION
## Summary
- add TypedDict for error details
- use `ErrorSummary` for summarizer API
- fix an indentation error in `security_auditor`

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: AttributeError: module 'geoip2' has no attribute 'database')*