### PR TITLE
Add type annotations and common types

### DIFF
--- a/src/pcap_tool/analysis/security/security_auditor.py
+++ b/src/pcap_tool/analysis/security/security_auditor.py
@@ -8,7 +8,7 @@ from ...utils import coalesce
 from ...core.decorators import handle_analysis_errors, log_performance
 
 if TYPE_CHECKING:  # pragma: no cover - for type hints only
-from ...enrichment import Enricher
+    from ...enrichment import Enricher
 
 
 class SecurityAuditor:

--- a/src/pcap_tool/core/__init__.py
+++ b/src/pcap_tool/core/__init__.py
@@ -2,6 +2,7 @@ from .config import settings
 from .constants import *  # noqa: F401,F403
 from .dependencies import container
 from .models import PcapRecord, ParsedHandle
+from .types import FlowKey, PacketData, AnalysisResult, FlowKeyTuple, PacketList, JSONDict
 from .exceptions import (
     PcapToolError,
     PcapParsingError,
@@ -19,6 +20,12 @@ __all__ = [
     "container",
     "PcapRecord",
     "ParsedHandle",
+    "FlowKey",
+    "PacketData",
+    "AnalysisResult",
+    "FlowKeyTuple",
+    "PacketList",
+    "JSONDict",
     "PcapToolError",
     "PcapParsingError",
     "CorruptPcapError",

--- a/src/pcap_tool/core/models.py
+++ b/src/pcap_tool/core/models.py
@@ -163,7 +163,7 @@ class PcapRecord:
 class ParsedHandle:
     """Represents parsed flows stored in memory or on disk."""
 
-    def __init__(self, backend: str, location: Any):
+    def __init__(self, backend: str, location: Any) -> None:
         self.backend = backend
         self.location = location
 

--- a/src/pcap_tool/core/types.py
+++ b/src/pcap_tool/core/types.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, TypedDict, Tuple, Union
+
+
+class FlowKey(TypedDict):
+    """Identifier for a network flow."""
+
+    src_ip: Optional[str]
+    dest_ip: Optional[str]
+    src_port: Optional[int]
+    dest_port: Optional[int]
+    protocol: Optional[str]
+
+
+class PacketData(TypedDict, total=False):
+    """Basic packet information."""
+
+    frame_number: int
+    timestamp: float
+    source_ip: Optional[str]
+    destination_ip: Optional[str]
+    source_port: Optional[int]
+    destination_port: Optional[int]
+    protocol: Optional[str]
+
+
+class AnalysisResult(TypedDict, total=False):
+    """Typed representation of aggregated analysis metrics."""
+
+    capture_info: Dict[str, Any]
+    protocols: Dict[str, Any]
+    top_ports: Dict[str, Any]
+    quic_vs_tls_packets: Dict[str, Any]
+    tls_version_counts: Dict[str, Any]
+    top_talkers_by_bytes: List[Dict[str, Any]]
+    top_talkers_by_packets: List[Dict[str, Any]]
+    service_overview: Dict[str, Any]
+    error_summary: Dict[str, Any]
+    performance_metrics: Dict[str, Any]
+    security_findings: Dict[str, Any]
+    timeline_data: List[Dict[str, Any]]
+    top_flows: List[Dict[str, Any]]
+
+
+FlowKeyTuple = Tuple[Optional[str], Optional[str], Optional[int], Optional[int], Optional[str]]
+PacketList = List[PacketData]
+JSONDict = Dict[str, Any]

--- a/src/pcap_tool/metrics/flow_table.py
+++ b/src/pcap_tool/metrics/flow_table.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Dict, Tuple, Iterable
 
+import pandas as pd
+
 from ..core.models import PcapRecord
 from ..utils import safe_int_or_default
 from ..heuristics.protocol_inference import guess_l7_protocol
@@ -86,7 +88,9 @@ class FlowTable:
         end = safe_int_or_default(end_ts, 0)
         return ",".join(str(bins.get(sec, 0)) for sec in range(start, end + 1))
 
-    def get_summary_df(self, top_n_bytes: int = 20, top_n_packets: int = 20):
+    def get_summary_df(
+        self, top_n_bytes: int = 20, top_n_packets: int = 20
+    ) -> tuple["pd.DataFrame", "pd.DataFrame"]:
         """Return two DataFrames ordered by bytes and packet count."""
         import pandas as pd
 

--- a/src/pcap_tool/parser/core.py
+++ b/src/pcap_tool/parser/core.py
@@ -1,4 +1,5 @@
 # src/pcap_tool/parser.py
+from __future__ import annotations
 from dataclasses import asdict
 from typing import TYPE_CHECKING, List, Optional
 from typing import (
@@ -411,7 +412,7 @@ def _parse_to_duckdb(
     chunk_size: int,
     on_progress: Callable[[int, Optional[int]], None] | None,
     workers: int | None,
-):
+) -> ParsedHandle:
     import duckdb
 
     conn = duckdb.connect(db_path)
@@ -441,7 +442,7 @@ def _parse_to_arrow(
     chunk_size: int,
     on_progress: Callable[[int, Optional[int]], None] | None,
     workers: int | None,
-):
+) -> ParsedHandle:
     import pyarrow as pa
     import pyarrow.ipc as ipc
 
@@ -464,7 +465,7 @@ def _parse_to_arrow(
 @handle_parse_errors
 @log_performance
 def parse_pcap(
-    file_like,
+    file_like: Path | IO[bytes],
     *,
     output_uri: str | None = None,
     workers: int | None = settings.max_workers,

--- a/src/pcap_tool/parser/pyshark_parser.py
+++ b/src/pcap_tool/parser/pyshark_parser.py
@@ -1,5 +1,7 @@
 from typing import Generator, Optional
 
+from ..core.models import PcapRecord
+
 from ..parsers.pyshark_parser import PySharkParser, USE_PYSHARK
 
 
@@ -9,7 +11,7 @@ def _parse_with_pyshark(
     *,
     start: int = 0,
     slice_size: Optional[int] = None,
-) -> Generator:
+) -> Generator[PcapRecord, None, None]:
     """Backwards compatible wrapper around :class:`PySharkParser`."""
 
     parser = PySharkParser()


### PR DESCRIPTION
## Summary
- define new typed dictionaries and aliases in `core/types.py`
- export new types from the `pcap_tool.core` package
- annotate parser helpers and flow table methods
- fix security auditor import guard
- type hint `_parse_with_pyshark`

## Testing
- `flake8 src/ tests/`
- `pytest -q` *(fails: AttributeError: module 'geoip2' has no attribute ...)*