### PR TITLE
Fix optional geoip2 import and re-export PDF helpers

### DIFF
--- a/src/pcap_tool/analysis/errors/error_summarizer.py
+++ b/src/pcap_tool/analysis/errors/error_summarizer.py
@@ -15,6 +15,8 @@ class ErrorDetail(TypedDict):
 
 
 ErrorSummary = Dict[str, Union[ErrorDetail, Dict[str, ErrorDetail]]]
+# Simple structure used when converting an ``ErrorSummary`` into a DataFrame.
+ErrorDataFrameRow = Dict[str, object]
 
 
 class ErrorSummarizer:

--- a/src/pcap_tool/enrichment/__init__.py
+++ b/src/pcap_tool/enrichment/__init__.py
@@ -10,14 +10,22 @@ from functools import lru_cache
 from typing import Any, Callable, Optional
 
 geoip2 = None
-Reader = None  # type: ignore
+Reader = None  # type: ignore[var-annotated]
 
 if container.is_available("geoip2"):
     geoip2 = container.get("geoip2")  # type: ignore
-    geoip2 = container.get("geoip2")  # type: ignore
-    Reader = geoip2.database.Reader  # type: ignore
-    AddressNotFoundError = geoip2.errors.AddressNotFoundError  # type: ignore
+    try:
+        from geoip2 import database as geoip2_database, errors as geoip2_errors
+
+        Reader = geoip2_database.Reader  # type: ignore[attr-defined]
+        AddressNotFoundError = geoip2_errors.AddressNotFoundError  # type: ignore[attr-defined]
+    except Exception:  # pragma: no cover - optional dependency handling
+        Reader = None  # type: ignore[var-annotated]
+
+        class AddressNotFoundError(Exception):
+            pass
 else:
+
     class AddressNotFoundError(Exception):
         """Fallback error if geoip2 is unavailable."""
 

--- a/src/pcap_tool/pdf_report.py
+++ b/src/pcap_tool/pdf_report.py
@@ -1,1 +1,24 @@
-from .reporting.pdf_report import *  # noqa: F401,F403
+"""Public PDF report API re-exported for convenience."""
+
+from .reporting import pdf_report as _pdf_report
+
+# Expose the element-building helper so tests can monkeypatch it
+_build_elements = _pdf_report._build_elements
+
+
+def generate_pdf_report(*args, **kwargs):
+    """Proxy to :func:`pcap_tool.reporting.pdf_report.generate_pdf_report`.
+
+    The helper ``_build_elements`` is looked up from this module so tests that
+    patch ``pcap_tool.pdf_report._build_elements`` affect the behaviour.
+    """
+
+    original = _pdf_report._build_elements
+    _pdf_report._build_elements = _build_elements
+    try:
+        return _pdf_report.generate_pdf_report(*args, **kwargs)
+    finally:
+        _pdf_report._build_elements = original
+
+
+__all__ = ["generate_pdf_report", "_build_elements"]


### PR DESCRIPTION
## Summary
- define `ErrorDataFrameRow` type so flake8 passes
- properly import `geoip2.database.Reader`
- rework PDF report wrapper so `_build_elements` can be patched in tests

## Testing
- `flake8 src/ tests/`
- `pytest -q`