### PR TITLE
Add configurable PCAP analysis pipeline

### DIFF
--- a/docs/pipeline.md
+++ b/docs/pipeline.md
@@ -1,0 +1,33 @@
+# Pipeline Architecture
+
+This project now includes a lightweight pipeline framework for chaining
+processing, analysis and reporting steps.  Pipelines can be configured
+programmatically or loaded from a YAML/JSON file.
+
+## Building a Pipeline
+
+```python
+from pcap_tool.pipeline import Pipeline, BaseProcessor
+
+pipeline = Pipeline()
+# pipeline.add_processor(MyProcessor())
+# pipeline.add_analyzer(MyAnalyzer())
+# pipeline.add_reporter(MyReporter())
+result = pipeline.run(input_data)
+```
+
+The ``on_progress`` callback passed to ``run`` receives the current
+step and total number of steps so UIs can display status information.
+
+## Configuration File Example
+
+```yaml
+processors:
+  - name: pcap_tool.processors.tcp_processor.TCPProcessor
+analyzers:
+  - name: pcap_tool.analyze.performance.PerformanceAnalyzer
+reporters:
+  - name: pcap_tool.reporting.summary.SummaryReporter
+```
+
+Load the configuration using ``Pipeline.from_config("config.yaml")``.

--- a/examples/pipelines/simple.yaml
+++ b/examples/pipelines/simple.yaml
@@ -1,0 +1,6 @@
+processors:
+  - name: pcap_tool.processors.tcp_processor.TCPProcessor
+analyzers:
+  - name: pcap_tool.analyze.performance.PerformanceAnalyzer
+reporters:
+  - name: pcap_tool.reporting.summary.SummaryReporter

--- a/src/pcap_tool/__init__.py
+++ b/src/pcap_tool/__init__.py
@@ -13,6 +13,7 @@ from .ai import prepare_ai_data
 from .metrics.stats_collector import StatsCollector
 from .analyze import PerformanceAnalyzer, ErrorSummarizer
 from .heuristics.engine import VectorisedHeuristicEngine
+from .pipeline import Pipeline, BaseProcessor, BaseAnalyzer, BaseReporter
 
 
 __all__ = [
@@ -32,4 +33,8 @@ __all__ = [
     "PerformanceAnalyzer",
     "ErrorSummarizer",
     "VectorisedHeuristicEngine",
+    "Pipeline",
+    "BaseProcessor",
+    "BaseAnalyzer",
+    "BaseReporter",
 ]

--- a/src/pcap_tool/pipeline/__init__.py
+++ b/src/pcap_tool/pipeline/__init__.py
@@ -1,0 +1,6 @@
+"""Pipeline framework for PCAP analysis."""
+
+from .base import Pipeline
+from .components import BaseAnalyzer, BaseProcessor, BaseReporter
+
+__all__ = ["Pipeline", "BaseProcessor", "BaseAnalyzer", "BaseReporter"]

--- a/src/pcap_tool/pipeline/base.py
+++ b/src/pcap_tool/pipeline/base.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Callable, Iterable, Optional
+import json
+
+import yaml
+
+from .components import BaseAnalyzer, BaseProcessor, BaseReporter
+
+
+@dataclass
+class Pipeline:
+    """Simple configurable pipeline for PCAP analysis."""
+
+    processors: list[BaseProcessor] = field(default_factory=list)
+    analyzers: list[BaseAnalyzer] = field(default_factory=list)
+    reporters: list[BaseReporter] = field(default_factory=list)
+
+    def add_processor(self, processor: BaseProcessor) -> None:
+        """Add ``processor`` to the pipeline."""
+        self.processors.append(processor)
+
+    def add_analyzer(self, analyzer: BaseAnalyzer) -> None:
+        """Add ``analyzer`` to the pipeline."""
+        self.analyzers.append(analyzer)
+
+    def add_reporter(self, reporter: BaseReporter) -> None:
+        """Add ``reporter`` to the pipeline."""
+        self.reporters.append(reporter)
+
+    def _iter_components(self) -> Iterable[Any]:
+        yield from self.processors
+        yield from self.analyzers
+        yield from self.reporters
+
+    def run(self, data: Any, on_progress: Optional[Callable[[int, Optional[int]], None]] = None) -> Any:
+        """Execute the pipeline with ``data``."""
+        total_steps = len(self.processors) + len(self.analyzers) + len(self.reporters)
+        step = 0
+        for component in self._iter_components():
+            step += 1
+            if on_progress:
+                on_progress(step, total_steps)
+            if isinstance(component, BaseProcessor):
+                data = component.process(data, on_progress=on_progress)
+            elif isinstance(component, BaseAnalyzer):
+                data = component.analyze(data)
+            elif isinstance(component, BaseReporter):
+                data = component.report(data)
+        if on_progress:
+            on_progress(total_steps, total_steps)
+        return data
+
+    @classmethod
+    def from_config(cls, path: str | Path) -> "Pipeline":
+        """Create a pipeline from a YAML or JSON configuration file."""
+        config_path = Path(path)
+        with config_path.open("r", encoding="utf-8") as fh:
+            suffix = config_path.suffix.lower()
+            if suffix in {".yaml", ".yml"}:
+                config = yaml.safe_load(fh)
+            elif suffix == ".json":
+                config = json.load(fh)
+            else:
+                raise ValueError(
+                    f"Unsupported configuration file format: '{config_path.suffix}'. "
+                    "Supported formats are YAML (.yaml, .yml) and JSON (.json)."
+                )
+
+        pipeline = cls()
+        for section, adder in (
+            ("processors", pipeline.add_processor),
+            ("analyzers", pipeline.add_analyzer),
+            ("reporters", pipeline.add_reporter),
+        ):
+            for item in config.get(section, []):
+                if isinstance(item, str):
+                    obj = _load_object(item, {})
+                else:
+                    name = item.get("name")
+                    if not isinstance(name, str) or not name:
+                        raise ValueError(
+                            f"Invalid or missing 'name' for component in section '{section}': {item}"
+                        )
+                    params = item.get("params", {})
+                    obj = _load_object(name, params)
+                adder(obj)
+        return pipeline
+
+def _load_object(path: str, params: dict) -> Any:
+    module_name, _, attr = path.rpartition(".")
+    module = import_module(module_name)
+    cls = getattr(module, attr)
+    return cls(**params)

--- a/src/pcap_tool/pipeline/components.py
+++ b/src/pcap_tool/pipeline/components.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Optional
+
+
+class BaseProcessor(ABC):
+    """Abstract base class for pipeline processors."""
+
+    @abstractmethod
+    def process(
+        self, data: Any, *, on_progress: Optional[Callable[[int, Optional[int]], None]] = None
+    ) -> Any:
+        """Process ``data`` and return the result."""
+
+
+class BaseAnalyzer(ABC):
+    """Abstract base class for pipeline analyzers."""
+
+    @abstractmethod
+    def analyze(self, data: Any) -> Any:
+        """Analyze ``data`` and return the result."""
+
+
+class BaseReporter(ABC):
+    """Abstract base class for pipeline reporters."""
+
+    @abstractmethod
+    def report(self, data: Any) -> Any:
+        """Generate a report from ``data`` and return the result."""


### PR DESCRIPTION
## Summary
- add `Pipeline` framework under `pcap_tool.pipeline`
- document how to build pipelines and include config example
- expose pipeline classes from top level package
- validate pipeline configuration format and entries

## Testing
- `flake8 src/ tests/`
- `pytest -q`
