### PR TITLE
feat: Add optional dependencies for IP defrag and TCP reassembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ pytest
 ```
 You can also run `make setup` to install everything needed for local testing.
 
+## Optional Features
+
+This project supports optional features that can be installed as extras. These features are only supported on Linux and macOS.
+
+### IP Defragmentation
+
+For IP defragmentation support, install the `defrag` extra:
+
+```bash
+pip install -e .[defrag]
+```
+
+### TCP Reassembly
+
+For TCP reassembly support, install the `reassembly` extra:
+
+```bash
+pip install -e .[reassembly]
+```
+
 ### Data Columns
 
 Parsed DataFrames include many fields from the capture.  The `is_src_client`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ readme = "README.md"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
+defrag = ["scapy>=2.5.0"]
+reassembly = ["pypcapkit>=1.3.5"]
 dev = [
     "pytest>=7.0",
     "flake8"

--- a/tests/unit/optional/test_extras_imports.py
+++ b/tests/unit/optional/test_extras_imports.py
@@ -6,4 +6,4 @@ def test_import_defrag():
 
 def test_import_reassembly():
     """Test that the reassembly extra (pcapkit) can be imported."""
-    pytest.importorskip("pcapkit")
+    pytest.importorskip("pypcapkit")

--- a/tests/unit/optional/test_extras_imports.py
+++ b/tests/unit/optional/test_extras_imports.py
@@ -1,0 +1,9 @@
+import pytest
+
+def test_import_defrag():
+    """Test that the defrag extra (scapy) can be imported."""
+    pytest.importorskip("scapy")
+
+def test_import_reassembly():
+    """Test that the reassembly extra (pcapkit) can be imported."""
+    pytest.importorskip("pcapkit")


### PR DESCRIPTION
This commit introduces optional dependencies for IP defragmentation and TCP reassembly.

The following changes are included:
- `pyproject.toml` is updated to include `defrag` and `reassembly` extras. `scapy` is used for defragmentation and `pypcapkit` for reassembly.
- `README.md` is updated to document the new optional features and how to install them.
- A smoke test is added to `tests/unit/optional/test_extras_imports.py` to verify that the optional dependencies can be imported correctly.

Note: The original request specified `pcapkit>=2.1.0`, but the correct package name is `pypcapkit`. The version was adjusted to be consistent with the existing `requirements.txt` file.