### PR TITLE
feat: stream parsed frames lazily

### DIFF
--- a/src/pcap_tool/core/models.py
+++ b/src/pcap_tool/core/models.py
@@ -154,18 +154,15 @@ class PcapRecord:
                 value = default
             else:
                 try:
-                    if pd.isna(value):  # handles NaN and pandas.NA
-                        value = default
+                    # Only check for NaN/NA for types where it makes sense
+                    if isinstance(value, (float, str)) or (
+                        hasattr(value, "__array__") or hasattr(value, "__float__")
+                    ):
+                        if pd.isna(value):  # handles NaN and pandas.NA
+                            value = default
                 except (TypeError, ValueError):
-                        # Intentionally ignore TypeError/ValueError from pd.isna for unsupported types.
-                        # In such cases, we assume the value is not NA and proceed.
-                except (TypeError, ValueError) as e:
-                        # pd.isna can raise TypeError for some types, assume not NA.
-                        logging.debug(f"pd.isna raised {type(e).__name__} for value {value!r}: {e}")
-                # Only check for NaN/NA for types where it makes sense
-                if isinstance(value, (float, str)) or (hasattr(value, "__array__") or hasattr(value, "__float__")):
-                    if pd.isna(value):  # handles NaN and pandas.NA
-                        value = default
+                    # pd.isna may raise for unsupported types; treat as not NA
+                    pass
 
             if base_type in (int,):
                 coerced = _safe_int(value)

--- a/src/pcap_tool/orchestrator/ingestor.py
+++ b/src/pcap_tool/orchestrator/ingestor.py
@@ -1,0 +1,49 @@
+"""Streaming ingestion helpers.
+
+This module exposes :func:`iter_parsed_frames` which provides a very light
+interface around the parser ``Factory``.  The existing parsers expose a
+``parse`` generator that yields raw dictionaries describing each packet.  The
+previous implementation in the project materialised those dictionaries into a
+``pandas`` ``DataFrame`` which required loading every packet into memory.  For
+large captures this approach was prohibitive.
+
+The function below replaces that behaviour with a streaming generator of
+``PcapRecord`` objects.  Each row produced by the parser is converted on the
+fly using :meth:`pcap_tool.core.models.PcapRecord.from_parser_row` and yielded
+immediately.  No intermediate list or ``DataFrame`` is built which keeps memory
+usage at :math:`O(1)` with respect to the number of packets processed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from collections.abc import Iterator
+
+from ..core.models import PcapRecord
+from ..parsers.factory import ParserFactory
+
+
+def iter_parsed_frames(path: str) -> Iterator[PcapRecord]:
+    """Yield :class:`PcapRecord` objects for packets contained in ``path``.
+
+    The appropriate parser backend is obtained from
+    :class:`pcap_tool.parsers.factory.ParserFactory`.  The backend returns an
+    iterator of *rows* (typically dictionaries) which are converted to
+    ``PcapRecord`` instances lazily.  Items are yielded as soon as they are
+    produced so the function's memory footprint remains constant regardless of
+    the size of the source PCAP.
+    """
+
+    parser = ParserFactory.create_parser()
+    for row in parser.parse(path, max_packets=None):
+        # ``row`` may already be a ``PcapRecord`` depending on the parser
+        # implementation.  Normalise by converting to a dictionary before
+        # feeding it into ``from_parser_row``.
+        if isinstance(row, PcapRecord):  # pragma: no cover - defensive
+            row_dict = asdict(row)
+        else:
+            row_dict = row
+        yield PcapRecord.from_parser_row(row_dict)
+
+
+__all__ = ["iter_parsed_frames"]

--- a/tests/unit/orchestrator/test_ingestor.py
+++ b/tests/unit/orchestrator/test_ingestor.py
@@ -1,0 +1,45 @@
+from collections.abc import Iterator
+
+from pcap_tool.core.models import PcapRecord
+from pcap_tool.orchestrator.ingestor import iter_parsed_frames
+from pcap_tool.parsers.factory import ParserFactory
+
+
+class DummyParser:
+    """Parser yielding a large number of lightweight rows lazily."""
+
+    def __init__(self, count: int) -> None:
+        self.count = count
+        self.generated = 0
+
+    @classmethod
+    def validate(cls) -> bool:  # pragma: no cover - not used directly
+        return True
+
+    def parse(self, file_path: str, max_packets, *, start: int = 0, slice_size=None):
+        for i in range(self.count):
+            self.generated += 1
+            yield {"frame_number": i}
+
+
+def test_iter_parsed_frames_streams_lazily(monkeypatch):
+    """Ensure records are produced lazily with constant memory."""
+
+    dummy = DummyParser(1_000_001)
+    monkeypatch.setattr(ParserFactory, "create_parser", lambda preferred=None: dummy)
+
+    gen = iter_parsed_frames("dummy.pcap")
+    assert isinstance(gen, Iterator)
+    assert dummy.generated == 0
+
+    # Consume a handful of records to verify streaming behaviour
+    first = next(gen)
+    assert isinstance(first, PcapRecord)
+    assert first.frame_number == 0
+    assert dummy.generated == 1
+
+    # Iterate over additional records without materialising the whole source
+    for i, rec in zip(range(1, 1000), gen):
+        assert rec.frame_number == i
+    assert dummy.generated == 1000  # only the consumed rows were generated
+    assert dummy.generated < dummy.count

--- a/tests/unit/orchestrator/test_ingestor.py
+++ b/tests/unit/orchestrator/test_ingestor.py
@@ -16,7 +16,7 @@ class DummyParser:
     def validate(cls) -> bool:  # pragma: no cover - not used directly
         return True
 
-    def parse(self, file_path: str, max_packets, *, start: int = 0, slice_size=None):
+    def parse(self, _file_path: str, *, max_packets=None, _start: int = 0, _slice_size=None):
         for i in range(self.count):
             self.generated += 1
             yield {"frame_number": i}


### PR DESCRIPTION
## Summary
- add `iter_parsed_frames` to orchestrator for lazy record streaming
- fix NaN checks in `PcapRecord.from_parser_row`
- cover ingestor with streaming semantics test

## Testing
- `flake8 src/ tests/`
- `pytest -q --disable-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68a34a8e35ac8322afd760f70fa73239