### PR TITLE
Harden PcapRecord model to prevent NaN values

### DIFF
--- a/src/pcap_tool/core/cache.py
+++ b/src/pcap_tool/core/cache.py
@@ -36,7 +36,7 @@ class FlowCache:
         stream_index: int | None,
         frame_number: int,
     ) -> str:
-        if stream_index is not None:
+        if stream_index is not None and stream_index > -1:
             return f"TCP_STREAM_{stream_index}"
         if src_ip and dst_ip and proto:
             props = sorted([(src_ip, src_port), (dst_ip, dst_port)])

--- a/src/pcap_tool/core/models.py
+++ b/src/pcap_tool/core/models.py
@@ -6,127 +6,245 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, List, Optional
 import pandas as pd
-
-
-def _safe_int(value: Any) -> Optional[int]:
-    """Safely convert numbers that may contain commas to ``int``."""
-
-    try:
-        return int(str(value).replace(",", ""))
-    except (TypeError, ValueError):
-        return None
+import math
 
 
 @dataclass
 class PcapRecord:
-    frame_number: int
-    timestamp: float
-    source_ip: Optional[str] = None
-    destination_ip: Optional[str] = None
-    source_port: Optional[int] = None
-    destination_port: Optional[int] = None
-    protocol: Optional[str] = None
-    sni: Optional[str] = None
-    raw_packet_summary: Optional[str] = None
-    source_mac: Optional[str] = None
-    destination_mac: Optional[str] = None
-    protocol_l3: Optional[str] = None
-    packet_length: Optional[int] = None
-    ip_ttl: Optional[int] = None
-    ip_flags_df: Optional[bool] = None
-    ip_id: Optional[str] = None
-    dscp_value: Optional[int] = None
-    tcp_flags_syn: Optional[bool] = None
-    tcp_flags_ack: Optional[bool] = None
-    tcp_flags_fin: Optional[bool] = None
-    tcp_flags_rst: Optional[bool] = None
-    tcp_flags_psh: Optional[bool] = None
-    tcp_flags_urg: Optional[bool] = None
-    tcp_flags_ece: Optional[bool] = None
-    tcp_flags_cwr: Optional[bool] = None
-    tcp_sequence_number: Optional[int] = None
-    tcp_acknowledgment_number: Optional[int] = None
-    tcp_window_size: Optional[int] = None
-    tcp_options_mss: Optional[int] = None
-    tcp_options_sack_permitted: Optional[bool] = None
-    tcp_options_window_scale: Optional[int] = None
-    tcp_stream_index: Optional[int] = None
-    is_src_client: Optional[bool] = None
-    is_source_client: Optional[bool] = None
+    frame_number: int = 0
+    timestamp: float = 0.0
+    source_ip: str = ""
+    destination_ip: str = ""
+    source_port: int = 0
+    destination_port: int = 0
+    protocol: str = ""
+    sni: str = ""
+    raw_packet_summary: str = ""
+    source_mac: str = ""
+    destination_mac: str = ""
+    protocol_l3: str = ""
+    packet_length: int = 0
+    ip_ttl: int = 0
+    ip_flags_df: bool = False
+    ip_id: str = ""
+    dscp_value: int = 0
+    tcp_flags_syn: bool = False
+    tcp_flags_ack: bool = False
+    tcp_flags_fin: bool = False
+    tcp_flags_rst: bool = False
+    tcp_flags_psh: bool = False
+    tcp_flags_urg: bool = False
+    tcp_flags_ece: bool = False
+    tcp_flags_cwr: bool = False
+    tcp_sequence_number: int = 0
+    tcp_acknowledgment_number: int = 0
+    tcp_window_size: int = 0
+    tcp_options_mss: int = 0
+    tcp_options_sack_permitted: bool = False
+    tcp_options_window_scale: int = 0
+    tcp_stream_index: int = 0
+    is_src_client: bool = False
+    is_source_client: bool = False
     tcp_analysis_retransmission_flags: List[str] = field(default_factory=list)
     tcp_analysis_duplicate_ack_flags: List[str] = field(default_factory=list)
     tcp_analysis_out_of_order_flags: List[str] = field(default_factory=list)
     tcp_analysis_window_flags: List[str] = field(default_factory=list)
-    dup_ack_num: Optional[int] = None
-    adv_window: Optional[int] = None
-    tcp_rtt_ms: Optional[float] = None
-    tls_handshake_type: Optional[str] = None
-    tls_handshake_version: Optional[str] = None
-    tls_record_version: Optional[str] = None
-    tls_cipher_suites_offered: Optional[List[str]] = None
-    tls_cipher_suite_selected: Optional[str] = None
-    tls_alert_message_description: Optional[str] = None
-    tls_alert_level: Optional[str] = None
-    tls_effective_version: Optional[str] = None
+    dup_ack_num: int = 0
+    adv_window: int = 0
+    tcp_rtt_ms: float = 0.0
+    tls_handshake_type: str = ""
+    tls_handshake_version: str = ""
+    tls_record_version: str = ""
+    tls_cipher_suites_offered: List[str] = field(default_factory=list)
+    tls_cipher_suite_selected: str = ""
+    tls_alert_message_description: str = ""
+    tls_alert_level: str = ""
+    tls_effective_version: str = ""
     # ── TLS certificate metadata ─────────────────────────────────────────
-    tls_cert_subject_cn: Optional[str] = None
-    tls_cert_san_dns: Optional[List[str]] = None  # list of DNS SANs
-    tls_cert_san_ip: Optional[List[str]] = None   # list of IP SANs
-    tls_cert_issuer_cn: Optional[str] = None
-    tls_cert_serial_number: Optional[str] = None
+    tls_cert_subject_cn: str = ""
+    tls_cert_san_dns: List[str] = field(default_factory=list)
+    tls_cert_san_ip: List[str] = field(default_factory=list)
+    tls_cert_issuer_cn: str = ""
+    tls_cert_serial_number: str = ""
     tls_cert_not_before: Optional[datetime] = None
     tls_cert_not_after: Optional[datetime] = None
-    tls_cert_sig_alg: Optional[str] = None
-    tls_cert_key_length: Optional[int] = None
-    tls_cert_is_self_signed: Optional[bool] = None
-    dns_query_name: Optional[str] = None
-    dns_query_type: Optional[str] = None
-    dns_response_code: Optional[str] = None
-    dns_response_addresses: Optional[List[str]] = None
-    dns_response_cname_target: Optional[str] = None
-    http_request_method: Optional[str] = None
-    http_request_uri: Optional[str] = None
-    http_request_host_header: Optional[str] = None
-    http_response_code: Optional[int] = None
-    http_response_location_header: Optional[str] = None
-    http_x_forwarded_for_header: Optional[str] = None
-    icmp_type: Optional[int] = None
-    icmp_code: Optional[int] = None
-    icmp_fragmentation_needed_original_mtu: Optional[int] = None
-    arp_opcode: Optional[int] = None
-    arp_sender_mac: Optional[str] = None
-    arp_sender_ip: Optional[str] = None
-    arp_target_mac: Optional[str] = None
-    arp_target_ip: Optional[str] = None
-    dhcp_message_type: Optional[str] = None
-    gre_protocol: Optional[str] = None
-    esp_spi: Optional[str] = None
-    quic_initial_packet_present: Optional[bool] = None
-    is_quic: Optional[bool] = None
-    is_zscaler_ip: Optional[bool] = None
-    is_zpa_synthetic_ip: Optional[bool] = None
-    ssl_inspection_active: Optional[bool] = None
-    zscaler_policy_block_type: Optional[str] = None
+    tls_cert_sig_alg: str = ""
+    tls_cert_key_length: int = 0
+    tls_cert_is_self_signed: bool = False
+    dns_query_name: str = ""
+    dns_query_type: str = ""
+    dns_response_code: str = ""
+    dns_response_addresses: List[str] = field(default_factory=list)
+    dns_response_cname_target: str = ""
+    http_request_method: str = ""
+    http_request_uri: str = ""
+    http_request_host_header: str = ""
+    http_response_code: int = 0
+    http_response_location_header: str = ""
+    http_x_forwarded_for_header: str = ""
+    icmp_type: int = 0
+    icmp_code: int = 0
+    icmp_fragmentation_needed_original_mtu: int = 0
+    arp_opcode: int = 0
+    arp_sender_mac: str = ""
+    arp_sender_ip: str = ""
+    arp_target_mac: str = ""
+    arp_target_ip: str = ""
+    dhcp_message_type: str = ""
+    gre_protocol: str = ""
+    esp_spi: str = ""
+    quic_initial_packet_present: bool = False
+    is_quic: bool = False
+    is_zscaler_ip: bool = False
+    is_zpa_synthetic_ip: bool = False
+    ssl_inspection_active: bool = False
+    zscaler_policy_block_type: str = ""
 
-    def __post_init__(self) -> None:
-        """Normalize key fields for consistency."""
+    @classmethod
+    def from_parser_row(cls, row: Any) -> "PcapRecord":
+        """
+        Factory method to create a PcapRecord from a parser row,
+        safely handling missing data, NaNs, and incorrect types.
+        """
+        def to_int(value: Any, default: int = 0) -> int:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return default
+            try:
+                return int(str(value).replace(",", ""))
+            except (ValueError, TypeError):
+                return default
 
-        try:
-            self.frame_number = int(self.frame_number)
-        except (TypeError, ValueError):
-            self.frame_number = 0
-        try:
-            self.timestamp = float(self.timestamp)
-        except (TypeError, ValueError):
-            self.timestamp = 0.0
+        def to_float(value: Any) -> float:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return 0.0
+            try:
+                return float(value)
+            except (ValueError, TypeError):
+                return 0.0
 
-        if isinstance(self.source_port, str):
-            self.source_port = _safe_int(self.source_port)
-        if isinstance(self.destination_port, str):
-            self.destination_port = _safe_int(self.destination_port)
+        def to_str(value: Any) -> str:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return ""
+            return str(value)
 
-        if isinstance(self.tcp_stream_index, str):
-            self.tcp_stream_index = _safe_int(self.tcp_stream_index)
+        def to_bool(value: Any) -> bool:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return False
+            if isinstance(value, str):
+                return value.lower().strip() in ('true', '1', 't', 'y', 'yes')
+            return bool(value)
+
+        def to_list(value: Any) -> list:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return []
+            if isinstance(value, (list, set, tuple)):
+                return list(value)
+            return []
+
+        def to_datetime(value: Any) -> Optional[datetime]:
+            if value is None or (isinstance(value, float) and pd.isna(value)):
+                return None
+            try:
+                # pyshark can return datetime strings with weird timezones like 'UTC-5'
+                # which pandas struggles with. We can strip them for now.
+                if isinstance(value, str) and ('UTC' in value or 'GMT' in value):
+                    value = value.split(" (")[0]
+                dt = pd.to_datetime(value)
+                if pd.isna(dt):
+                    return None
+                return dt
+            except (ValueError, TypeError):
+                return None
+
+        return cls(
+            frame_number=to_int(getattr(row, 'frame_number', 0)),
+            timestamp=to_float(getattr(row, 'timestamp', 0.0)),
+            source_ip=to_str(getattr(row, 'source_ip', "")),
+            destination_ip=to_str(getattr(row, 'destination_ip', "")),
+            source_port=to_int(getattr(row, 'source_port', 0)),
+            destination_port=to_int(getattr(row, 'destination_port', 0)),
+            protocol=to_str(getattr(row, 'protocol', "")),
+            sni=to_str(getattr(row, 'sni', "")),
+            raw_packet_summary=to_str(getattr(row, 'raw_packet_summary', "")),
+            source_mac=to_str(getattr(row, 'source_mac', "")),
+            destination_mac=to_str(getattr(row, 'destination_mac', "")),
+            protocol_l3=to_str(getattr(row, 'protocol_l3', "")),
+            packet_length=to_int(getattr(row, 'packet_length', 0)),
+            ip_ttl=to_int(getattr(row, 'ip_ttl', 0)),
+            ip_flags_df=to_bool(getattr(row, 'ip_flags_df', False)),
+            ip_id=to_str(getattr(row, 'ip_id', "")),
+            dscp_value=to_int(getattr(row, 'dscp_value', 0)),
+            tcp_flags_syn=to_bool(getattr(row, 'tcp_flags_syn', False)),
+            tcp_flags_ack=to_bool(getattr(row, 'tcp_flags_ack', False)),
+            tcp_flags_fin=to_bool(getattr(row, 'tcp_flags_fin', False)),
+            tcp_flags_rst=to_bool(getattr(row, 'tcp_flags_rst', False)),
+            tcp_flags_psh=to_bool(getattr(row, 'tcp_flags_psh', False)),
+            tcp_flags_urg=to_bool(getattr(row, 'tcp_flags_urg', False)),
+            tcp_flags_ece=to_bool(getattr(row, 'tcp_flags_ece', False)),
+            tcp_flags_cwr=to_bool(getattr(row, 'tcp_flags_cwr', False)),
+            tcp_sequence_number=to_int(getattr(row, 'tcp_sequence_number', 0)),
+            tcp_acknowledgment_number=to_int(getattr(row, 'tcp_acknowledgment_number', 0)),
+            tcp_window_size=to_int(getattr(row, 'tcp_window_size', 0)),
+            tcp_options_mss=to_int(getattr(row, 'tcp_options_mss', 0)),
+            tcp_options_sack_permitted=to_bool(getattr(row, 'tcp_options_sack_permitted', False)),
+            tcp_options_window_scale=to_int(getattr(row, 'tcp_options_window_scale', 0)),
+            tcp_stream_index=to_int(getattr(row, 'tcp_stream_index', None), default=-1),
+            is_src_client=to_bool(getattr(row, 'is_src_client', False)),
+            is_source_client=to_bool(getattr(row, 'is_source_client', False)),
+            tcp_analysis_retransmission_flags=to_list(getattr(row, 'tcp_analysis_retransmission_flags', [])),
+            tcp_analysis_duplicate_ack_flags=to_list(getattr(row, 'tcp_analysis_duplicate_ack_flags', [])),
+            tcp_analysis_out_of_order_flags=to_list(getattr(row, 'tcp_analysis_out_of_order_flags', [])),
+            tcp_analysis_window_flags=to_list(getattr(row, 'tcp_analysis_window_flags', [])),
+            dup_ack_num=to_int(getattr(row, 'dup_ack_num', 0)),
+            adv_window=to_int(getattr(row, 'adv_window', 0)),
+            tcp_rtt_ms=to_float(getattr(row, 'tcp_rtt_ms', 0.0)),
+            tls_handshake_type=to_str(getattr(row, 'tls_handshake_type', "")),
+            tls_handshake_version=to_str(getattr(row, 'tls_handshake_version', "")),
+            tls_record_version=to_str(getattr(row, 'tls_record_version', "")),
+            tls_cipher_suites_offered=to_list(getattr(row, 'tls_cipher_suites_offered', [])),
+            tls_cipher_suite_selected=to_str(getattr(row, 'tls_cipher_suite_selected', "")),
+            tls_alert_message_description=to_str(getattr(row, 'tls_alert_message_description', "")),
+            tls_alert_level=to_str(getattr(row, 'tls_alert_level', "")),
+            tls_effective_version=to_str(getattr(row, 'tls_effective_version', "")),
+            tls_cert_subject_cn=to_str(getattr(row, 'tls_cert_subject_cn', "")),
+            tls_cert_san_dns=to_list(getattr(row, 'tls_cert_san_dns', [])),
+            tls_cert_san_ip=to_list(getattr(row, 'tls_cert_san_ip', [])),
+            tls_cert_issuer_cn=to_str(getattr(row, 'tls_cert_issuer_cn', "")),
+            tls_cert_serial_number=to_str(getattr(row, 'tls_cert_serial_number', "")),
+            tls_cert_not_before=to_datetime(getattr(row, 'tls_cert_not_before', None)),
+            tls_cert_not_after=to_datetime(getattr(row, 'tls_cert_not_after', None)),
+            tls_cert_sig_alg=to_str(getattr(row, 'tls_cert_sig_alg', "")),
+            tls_cert_key_length=to_int(getattr(row, 'tls_cert_key_length', 0)),
+            tls_cert_is_self_signed=to_bool(getattr(row, 'tls_cert_is_self_signed', False)),
+            dns_query_name=to_str(getattr(row, 'dns_query_name', "")),
+            dns_query_type=to_str(getattr(row, 'dns_query_type', "")),
+            dns_response_code=to_str(getattr(row, 'dns_response_code', "")),
+            dns_response_addresses=to_list(getattr(row, 'dns_response_addresses', [])),
+            dns_response_cname_target=to_str(getattr(row, 'dns_response_cname_target', "")),
+            http_request_method=to_str(getattr(row, 'http_request_method', "")),
+            http_request_uri=to_str(getattr(row, 'http_request_uri', "")),
+            http_request_host_header=to_str(getattr(row, 'http_request_host_header', "")),
+            http_response_code=to_int(getattr(row, 'http_response_code', 0)),
+            http_response_location_header=to_str(getattr(row, 'http_response_location_header', "")),
+            http_x_forwarded_for_header=to_str(getattr(row, 'http_x_forwarded_for_header', "")),
+            icmp_type=to_int(getattr(row, 'icmp_type', 0)),
+            icmp_code=to_int(getattr(row, 'icmp_code', 0)),
+            icmp_fragmentation_needed_original_mtu=to_int(getattr(row, 'icmp_fragmentation_needed_original_mtu', 0)),
+            arp_opcode=to_int(getattr(row, 'arp_opcode', 0)),
+            arp_sender_mac=to_str(getattr(row, 'arp_sender_mac', "")),
+            arp_sender_ip=to_str(getattr(row, 'arp_sender_ip', "")),
+            arp_target_mac=to_str(getattr(row, 'arp_target_mac', "")),
+            arp_target_ip=to_str(getattr(row, 'arp_target_ip', "")),
+            dhcp_message_type=to_str(getattr(row, 'dhcp_message_type', "")),
+            gre_protocol=to_str(getattr(row, 'gre_protocol', "")),
+            esp_spi=to_str(getattr(row, 'esp_spi', "")),
+            quic_initial_packet_present=to_bool(getattr(row, 'quic_initial_packet_present', False)),
+            is_quic=to_bool(getattr(row, 'is_quic', False)),
+            is_zscaler_ip=to_bool(getattr(row, 'is_zscaler_ip', False)),
+            is_zpa_synthetic_ip=to_bool(getattr(row, 'is_zpa_synthetic_ip', False)),
+            ssl_inspection_active=to_bool(getattr(row, 'ssl_inspection_active', False)),
+            zscaler_policy_block_type=to_str(getattr(row, 'zscaler_policy_block_type', "")),
+        )
 
     def __str__(self) -> str:
         # ... (previous __str__ content, potentially updated for new fields) ...

--- a/src/pcap_tool/core/models.py
+++ b/src/pcap_tool/core/models.py
@@ -188,7 +188,7 @@ class PcapRecord:
             tcp_options_mss=to_int(getattr(row, 'tcp_options_mss', 0)),
             tcp_options_sack_permitted=to_bool(getattr(row, 'tcp_options_sack_permitted', False)),
             tcp_options_window_scale=to_int(getattr(row, 'tcp_options_window_scale', 0)),
-            tcp_stream_index=to_int(getattr(row, 'tcp_stream_index', None), default=-1),
+            tcp_stream_index=to_int(getattr(row, 'tcp_stream_index', None), default=0),
             is_src_client=to_bool(getattr(row, 'is_src_client', False)),
             is_source_client=to_bool(getattr(row, 'is_source_client', False)),
             tcp_analysis_retransmission_flags=to_list(getattr(row, 'tcp_analysis_retransmission_flags', [])),

--- a/src/pcap_tool/parsers/pcapkit_parser.py
+++ b/src/pcap_tool/parsers/pcapkit_parser.py
@@ -221,7 +221,6 @@ def _parse_with_pcapkit(file_path: str, max_packets: Optional[int]) -> Generator
                 def __init__(self, *args, **kwargs):
                     super(AttrDict, self).__init__(*args, **kwargs)
                     self.__dict__ = self
-
             yield PcapRecord.from_parser_row(AttrDict(record_dict))
 
             generated_records += 1

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -32,111 +32,6 @@ if TYPE_CHECKING:  # pragma: no cover - hint for static analyzers
     from pyshark.packet.packet import Packet as PySharkPacket
 
 
-def _get_pyshark_layer_attribute(layer: Any, attribute_name: str, frame_number_for_log: int, is_flag: bool = False) -> Any:
-    """Helper to safely get an attribute from a pyshark layer."""
-    if not hasattr(layer, attribute_name):
-        return None
-
-    raw_value = getattr(layer, attribute_name)
-
-    if is_flag:
-        bool_val = _safe_str_to_bool(raw_value)
-        if bool_val is None and raw_value is not None:
-            logger.warning(
-                f"Frame {frame_number_for_log}: Could not convert flag '{attribute_name}' with value '{raw_value}' to bool. Using None."
-            )
-        return bool_val
-
-    return raw_value
-
-
-def _extract_sni_pyshark(packet: "pyshark.packet.packet.Packet") -> Optional[str]:
-    logger.debug(f"Frame {packet.number}: Attempting SNI extraction (V_FIXED_ACCESS).")
-    sni_value = None
-    try:
-        if not hasattr(packet, "tls"):
-            return None
-        top_tls_layer = packet.tls
-        if hasattr(top_tls_layer, "_all_fields"):
-            logger.debug(
-                f"Frame {packet.number}: Fields in top_tls_layer (packet.tls): {top_tls_layer._all_fields}"
-            )
-        record_data = None
-        if hasattr(top_tls_layer, "tls_record"):
-            record_data = top_tls_layer.tls_record
-        elif "tls.record" in top_tls_layer.field_names:
-            record_data = top_tls_layer.get_field_value("tls.record")
-        else:
-            if hasattr(top_tls_layer, "tls_handshake"):
-                record_data = top_tls_layer
-        if not record_data:
-            if hasattr(top_tls_layer, "handshake_extensions_server_name"):
-                sni_value = top_tls_layer.handshake_extensions_server_name
-            return sni_value
-        handshake_data = None
-        if hasattr(record_data, "tls_handshake"):
-            handshake_data = record_data.tls_handshake
-        elif "tls.handshake" in record_data.field_names:
-            handshake_data = record_data.get_field_value("tls.handshake")
-        else:
-            return sni_value
-        if not handshake_data:
-            return sni_value
-        extension_data = None
-        if hasattr(handshake_data, "tls_handshake_extension"):
-            extension_data = handshake_data.tls_handshake_extension
-        elif "tls.handshake.extension" in handshake_data.field_names:
-            extension_data = handshake_data.get_field_value("tls.handshake.extension")
-        else:
-            return sni_value
-        if not extension_data:
-            return sni_value
-        extensions_to_check = []
-        if isinstance(extension_data, list):
-            extensions_to_check.extend(extension_data)
-        else:
-            extensions_to_check.append(extension_data)
-        for ext_entry in extensions_to_check:
-            if hasattr(ext_entry, "server_name_indication_extension"):
-                sni_details_obj = ext_entry.server_name_indication_extension
-                if hasattr(sni_details_obj, "extensions_server_name"):
-                    sni_value = sni_details_obj.extensions_server_name
-                    break
-                elif hasattr(sni_details_obj, "tls_handshake_extensions_server_name"):
-                    sni_value = sni_details_obj.tls_handshake_extensions_server_name
-                    break
-        if isinstance(sni_value, list):
-            sni_value = sni_value[0] if sni_value else None
-    except Exception as e:  # pragma: no cover - best effort only
-        logger.error(f"Frame {packet.number}: General exception in _extract_sni_pyshark: {e}", exc_info=True)
-        sni_value = None
-    if sni_value is None:
-        logger.debug(f"Frame {packet.number}: Final SNI extraction resulted in None.")
-    else:
-        logger.info(f"Frame {packet.number}: Final SNI value determined: {sni_value}")
-    return sni_value
-
-
-
-
-class PacketExtractor:
-    """Lightweight helper for extracting fields from a pyshark packet."""
-
-    def __init__(self, packet: "PySharkPacket") -> None:
-        """Store the packet reference.
-
-        The type is annotated as a string so importing this module does not
-        require :mod:`pyshark` to be installed.
-        """
-        self.packet = packet
-
-    def get(self, layer: str, attr: str, frame_number: int, *, is_flag: bool = False) -> Any:
-        if not hasattr(self.packet, layer):
-            return None
-        layer_obj = getattr(self.packet, layer)
-        return _get_pyshark_layer_attribute(layer_obj, attr, frame_number, is_flag)
-
-
 class PySharkParser(BaseParser):
     """Parser implementation using :mod:`pyshark` with helper methods."""
 
@@ -204,48 +99,88 @@ class PySharkParser(BaseParser):
 
     def _packet_to_record(self, packet: "PySharkPacket") -> PcapRecord:
         """Convert a ``pyshark`` packet to :class:`PcapRecord`."""
-
         ts = float(packet.sniff_timestamp)
         frame_number = _safe_int(packet.number) or 0
-        record = PcapRecord(frame_number=frame_number, timestamp=ts, raw_packet_summary=str(getattr(packet, "highest_layer", "")))
+
+        # Create a dictionary of the parsed data
+        row_data = {
+            "frame_number": frame_number,
+            "timestamp": ts,
+            "raw_packet_summary": str(getattr(packet, "highest_layer", "")),
+        }
+
+        # The concept of a PacketExtractor is still useful, so we create it here.
+        # This avoids passing the raw packet to every processor.
+        class PacketExtractor:
+            def __init__(self, packet: "PySharkPacket") -> None:
+                self.packet = packet
+
+            def get(self, layer: str, attr: str, frame_number: int, *, is_flag: bool = False) -> Any:
+                if not hasattr(self.packet, layer):
+                    return None
+                layer_obj = getattr(self.packet, layer)
+                raw_value = getattr(layer_obj, attr, None)
+                if is_flag:
+                    return _safe_str_to_bool(raw_value)
+                return raw_value
+
         extractor = PacketExtractor(packet)
-        self._extract_layer_data(extractor, record)
+        self._extract_layer_data(packet, row_data)
+
+        # Create a temporary record for processors that might need it for now.
+        # This can be refactored later.
+        temp_record = PcapRecord(**row_data)
+
         for proc in self.processors:
-            data = proc.process_packet(extractor, record)
-            for key, value in data.items():
-                setattr(record, key, value)
-        return record
+            data = proc.process_packet(extractor, temp_record)
+            row_data.update(data)
 
-    def _extract_layer_data(self, ext: PacketExtractor, record: PcapRecord) -> None:
-        """Populate L2/L3/L4 fields on ``record``."""
+        # Use a simple object to pass to the factory method because it expects attribute access
+        class AttrDict(dict):
+            def __init__(self, *args, **kwargs):
+                super(AttrDict, self).__init__(*args, **kwargs)
+                self.__dict__ = self
 
-        record.packet_length = _safe_int(getattr(ext.packet, "length", None))
+        return PcapRecord.from_parser_row(AttrDict(row_data))
 
-        record.source_mac = ext.get("eth", "src", record.frame_number)
-        record.destination_mac = ext.get("eth", "dst", record.frame_number)
+    def _extract_layer_data(self, packet: "PySharkPacket", record_dict: dict[str, Any]) -> None:
+        """Populate L2/L3/L4 fields on ``record_dict``."""
+        record_dict["packet_length"] = _safe_int(getattr(packet, "length", None))
 
-        if hasattr(ext.packet, "ip"):
-            record.protocol_l3 = "IPv4"
-            record.source_ip = ext.get("ip", "src", record.frame_number)
-            record.destination_ip = ext.get("ip", "dst", record.frame_number)
-            record.ip_ttl = _safe_int(ext.get("ip", "ttl", record.frame_number))
-            record.ip_flags_df = ext.get("ip", "flags_df", record.frame_number, is_flag=True)
-            proto = _safe_int(ext.get("ip", "proto", record.frame_number))
-            record.protocol = {1: "ICMP", 6: "TCP", 17: "UDP", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
-        elif hasattr(ext.packet, "ipv6"):
-            record.protocol_l3 = "IPv6"
-            record.source_ip = ext.get("ipv6", "src", record.frame_number)
-            record.destination_ip = ext.get("ipv6", "dst", record.frame_number)
-            record.ip_ttl = _safe_int(ext.get("ipv6", "hlim", record.frame_number))
-            proto = _safe_int(ext.get("ipv6", "nxt", record.frame_number))
-            record.protocol = {6: "TCP", 17: "UDP", 58: "ICMPv6", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
-        elif hasattr(ext.packet, "arp"):
-            record.protocol_l3 = "ARP"
-            record.arp_opcode = _safe_int(ext.get("arp", "opcode", record.frame_number))
-            record.arp_sender_mac = ext.get("arp", "src_hw_mac", record.frame_number)
-            record.arp_sender_ip = ext.get("arp", "src_proto_ipv4", record.frame_number)
-            record.arp_target_mac = ext.get("arp", "dst_hw_mac", record.frame_number)
-            record.arp_target_ip = ext.get("arp", "dst_proto_ipv4", record.frame_number)
+        if hasattr(packet, "eth"):
+            record_dict["source_mac"] = getattr(packet.eth, "src", None)
+            record_dict["destination_mac"] = getattr(packet.eth, "dst", None)
+
+        # Add L4 port info if available
+        if hasattr(packet, "tcp"):
+            record_dict["source_port"] = _safe_int(getattr(packet.tcp, "srcport", None))
+            record_dict["destination_port"] = _safe_int(getattr(packet.tcp, "dstport", None))
+        elif hasattr(packet, "udp"):
+            record_dict["source_port"] = _safe_int(getattr(packet.udp, "srcport", None))
+            record_dict["destination_port"] = _safe_int(getattr(packet.udp, "dstport", None))
+
+        if hasattr(packet, "ip"):
+            record_dict["protocol_l3"] = "IPv4"
+            record_dict["source_ip"] = getattr(packet.ip, "src", None)
+            record_dict["destination_ip"] = getattr(packet.ip, "dst", None)
+            record_dict["ip_ttl"] = _safe_int(getattr(packet.ip, "ttl", None))
+            record_dict["ip_flags_df"] = _safe_str_to_bool(getattr(packet.ip, "flags_df", "0"))
+            proto = _safe_int(getattr(packet.ip, "proto", None))
+            record_dict["protocol"] = {1: "ICMP", 6: "TCP", 17: "UDP", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
+        elif hasattr(packet, "ipv6"):
+            record_dict["protocol_l3"] = "IPv6"
+            record_dict["source_ip"] = getattr(packet.ipv6, "src", None)
+            record_dict["destination_ip"] = getattr(packet.ipv6, "dst", None)
+            record_dict["ip_ttl"] = _safe_int(getattr(packet.ipv6, "hlim", None))
+            proto = _safe_int(getattr(packet.ipv6, "nxt", None))
+            record_dict["protocol"] = {6: "TCP", 17: "UDP", 58: "ICMPv6", 47: "GRE", 50: "ESP"}.get(proto, str(proto) if proto is not None else None)
+        elif hasattr(packet, "arp"):
+            record_dict["protocol_l3"] = "ARP"
+            record_dict["arp_opcode"] = _safe_int(getattr(packet.arp, "opcode", None))
+            record_dict["arp_sender_mac"] = getattr(packet.arp, "src_hw_mac", None)
+            record_dict["arp_sender_ip"] = getattr(packet.arp, "src_proto_ipv4", None)
+            record_dict["arp_target_mac"] = getattr(packet.arp, "dst_hw_mac", None)
+            record_dict["arp_target_ip"] = getattr(packet.arp, "dst_proto_ipv4", None)
 
 
     @handle_parse_errors

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -123,7 +123,6 @@ class PySharkParser(BaseParser):
                 if is_flag:
                     return _safe_str_to_bool(raw_value)
                 return raw_value
-
         extractor = PacketExtractor(packet)
         self._extract_layer_data(packet, row_data)
 

--- a/src/pcap_tool/parsers/pyshark_parser.py
+++ b/src/pcap_tool/parsers/pyshark_parser.py
@@ -139,7 +139,6 @@ class PySharkParser(BaseParser):
             def __init__(self, *args, **kwargs):
                 super(AttrDict, self).__init__(*args, **kwargs)
                 self.__dict__ = self
-
         return PcapRecord.from_parser_row(AttrDict(row_data))
 
     def _extract_layer_data(self, packet: "PySharkPacket", record_dict: dict[str, Any]) -> None:

--- a/tests/test_nan_handling.py
+++ b/tests/test_nan_handling.py
@@ -1,55 +1,67 @@
 import math
-from pcap_tool.analyze import PerformanceAnalyzer
-from pcap_tool.models import PcapRecord
+import pandas as pd
+from pcap_tool.core.models import PcapRecord
 from pcap_tool.pipeline_app import _derive_flow_id, _flow_cache_key
 from pcap_tool.metrics.flow_table import FlowTable
+from pcap_tool.analysis.performance.performance_analyzer import PerformanceAnalyzer
 
+
+class AttrDict(dict):
+    """A dictionary that allows attribute-style access."""
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
 
 
 def test_derive_flow_id_nan_ports():
-    rec = PcapRecord(
-        frame_number=1,
-        timestamp=0.0,
-        source_ip="1.1.1.1",
-        destination_ip="2.2.2.2",
-        source_port=math.nan,
-        destination_port=math.nan,
-        protocol="TCP",
-    )
+    row = AttrDict({
+        "frame_number": 1,
+        "timestamp": 0.0,
+        "source_ip": "1.1.1.1",
+        "destination_ip": "2.2.2.2",
+        "source_port": math.nan,
+        "destination_port": math.nan,
+        "protocol": "TCP",
+    })
+    rec = PcapRecord.from_parser_row(row)
     assert _derive_flow_id(rec) == ("1.1.1.1", "2.2.2.2", 0, 0, "TCP")
 
 
 def test_flow_cache_key_nan_ports():
-    rec = PcapRecord(
-        frame_number=1,
-        timestamp=0.0,
-        source_ip="1.1.1.1",
-        destination_ip="2.2.2.2",
-        source_port=math.nan,
-        destination_port=math.nan,
-        protocol="TCP",
-    )
+    row = AttrDict({
+        "frame_number": 1,
+        "timestamp": 0.0,
+        "source_ip": "1.1.1.1",
+        "destination_ip": "2.2.2.2",
+        "source_port": math.nan,
+        "destination_port": math.nan,
+        "protocol": "TCP",
+        "tcp_stream_index": None,  # Explicitly set to None to avoid the TCP_STREAM path
+    })
+    rec = PcapRecord.from_parser_row(row)
     assert _flow_cache_key(rec) == "TCP_1.1.1.1:0_2.2.2.2:0"
 
 
 def test_performance_analyzer_nan_sequence():
     analyzer = PerformanceAnalyzer()
-    syn = PcapRecord(
-        frame_number=1,
-        timestamp=1.0,
-        protocol="TCP",
-        tcp_flags_syn=True,
-        tcp_flags_ack=False,
-        tcp_sequence_number=math.nan,
-    )
-    sa = PcapRecord(
-        frame_number=2,
-        timestamp=1.1,
-        protocol="TCP",
-        tcp_flags_syn=True,
-        tcp_flags_ack=True,
-        tcp_acknowledgment_number=math.nan,
-    )
+    syn_row = AttrDict({
+        "frame_number": 1,
+        "timestamp": 1.0,
+        "protocol": "TCP",
+        "tcp_flags_syn": True,
+        "tcp_flags_ack": False,
+        "tcp_sequence_number": math.nan,
+    })
+    sa_row = AttrDict({
+        "frame_number": 2,
+        "timestamp": 1.1,
+        "protocol": "TCP",
+        "tcp_flags_syn": True,
+        "tcp_flags_ack": True,
+        "tcp_acknowledgment_number": math.nan,
+    })
+    syn = PcapRecord.from_parser_row(syn_row)
+    sa = PcapRecord.from_parser_row(sa_row)
     analyzer.add_packet(syn, "flow", True)
     analyzer.add_packet(sa, "flow", False)
     assert analyzer.get_summary()["tcp_rtt_ms"]["samples"] == 0
@@ -57,16 +69,17 @@ def test_performance_analyzer_nan_sequence():
 
 def test_flow_table_nan_values():
     table = FlowTable()
-    rec = PcapRecord(
-        frame_number=1,
-        timestamp=1.0,
-        source_ip="1.1.1.1",
-        destination_ip="2.2.2.2",
-        source_port=math.nan,
-        destination_port=math.nan,
-        packet_length=math.nan,
-        protocol="TCP",
-    )
+    row = AttrDict({
+        "frame_number": 1,
+        "timestamp": 1.0,
+        "source_ip": "1.1.1.1",
+        "destination_ip": "2.2.2.2",
+        "source_port": math.nan,
+        "destination_port": math.nan,
+        "packet_length": math.nan,
+        "protocol": "TCP",
+    })
+    rec = PcapRecord.from_parser_row(row)
     table.add_packet(rec, True)
     df, _ = table.get_summary_df()
     assert df.iloc[0]["src_port"] == 0

--- a/tests/test_tcp_rtt.py
+++ b/tests/test_tcp_rtt.py
@@ -32,14 +32,14 @@ def syn_only_pcap(tmp_path: Path) -> Path:
 def test_tcp_rtt_extraction(handshake_pcap: Path):
     df = parse_pcap_to_df(str(handshake_pcap))
     assert "tcp_rtt_ms" in df.columns
-    rtts = df["tcp_rtt_ms"].dropna().tolist()
+    rtts = df[df["tcp_rtt_ms"] > 0]["tcp_rtt_ms"].tolist()
     assert len(rtts) == 1
     assert 999 <= rtts[0] <= 1001
 
 
 def test_syn_without_synack(syn_only_pcap: Path):
     df = parse_pcap_to_df(str(syn_only_pcap))
-    assert df["tcp_rtt_ms"].dropna().empty
+    assert (df["tcp_rtt_ms"] == 0.0).all()
 
 
 def test_compute_tcp_rtt_stats_empty():

--- a/tests/unit/core/test_pcaprecord_defaults.py
+++ b/tests/unit/core/test_pcaprecord_defaults.py
@@ -1,0 +1,57 @@
+# tests/unit/core/test_pcaprecord_defaults.py
+
+import pytest
+import pandas as pd
+from pcap_tool.core.models import PcapRecord
+import math
+
+class AttrDict(dict):
+    """A dictionary that allows attribute-style access."""
+    def __init__(self, *args, **kwargs):
+        super(AttrDict, self).__init__(*args, **kwargs)
+        self.__dict__ = self
+
+def test_from_parser_row_handles_missing_fields():
+    """Tests that the factory method provides defaults for missing fields."""
+    row = AttrDict({})
+    record = PcapRecord.from_parser_row(row)
+    assert record.frame_number == 0
+    assert record.source_ip == ""
+    assert record.packet_length == 0
+    assert record.ip_flags_df is False
+
+def test_from_parser_row_handles_none_and_nan():
+    """Tests that None and NaN are converted to their defaults."""
+    row = AttrDict({
+        "frame_number": None,
+        "source_port": pd.NA,
+        "ip_ttl": float('nan'),
+        "protocol": None,
+    })
+    record = PcapRecord.from_parser_row(row)
+    assert record.frame_number == 0
+    assert record.source_port == 0
+    assert record.ip_ttl == 0
+    assert record.protocol == ""
+
+def test_from_parser_row_coerces_types():
+    """Tests that string representations of numbers are coerced."""
+    row = AttrDict({
+        "frame_number": "123",
+        "timestamp": "123.456",
+        "source_port": "8080",
+        "ip_flags_df": "True",
+    })
+    record = PcapRecord.from_parser_row(row)
+    assert record.frame_number == 123
+    assert record.timestamp == 123.456
+    assert record.source_port == 8080
+    assert record.ip_flags_df is True
+
+def test_successful_numeric_operations():
+    """Ensures that fields are numeric and can be used in operations."""
+    row = AttrDict({"packet_length": "1500", "ip_ttl": "64"})
+    record = PcapRecord.from_parser_row(row)
+    # This will raise a TypeError if the fields are not numbers
+    result = record.packet_length - record.ip_ttl
+    assert result == 1436

--- a/tests/unit/core/test_pcaprecord_defaults.py
+++ b/tests/unit/core/test_pcaprecord_defaults.py
@@ -13,7 +13,11 @@ class AttrDict(dict):
 
 def test_from_parser_row_handles_missing_fields():
     """Tests that the factory method provides defaults for missing fields."""
-    row = AttrDict({})
+import types
+
+def test_from_parser_row_handles_missing_fields():
+    """Tests that the factory method provides defaults for missing fields."""
+    row = types.SimpleNamespace()
     record = PcapRecord.from_parser_row(row)
     assert record.frame_number == 0
     assert record.source_ip == ""

--- a/tests/unit/orchestrator/test_import.py
+++ b/tests/unit/orchestrator/test_import.py
@@ -7,4 +7,4 @@ def test_import_orchestrator():
     try:
         import pcap_tool.orchestrator
     except ImportError as e:
-    import pcap_tool.orchestrator
+        pytest.fail(f"Failed to import orchestrator: {e}")


### PR DESCRIPTION
This change addresses the issue of NaN values propagating through the system from the parsers.

Key changes:
- The `PcapRecord` dataclass fields are now non-optional with sane defaults (e.g., 0, "", False).
- A new class method, `PcapRecord.from_parser_row`, is introduced to centralize data cleaning and type coercion. This factory safely handles missing data, None/NaN values, and incorrect types from parser output.
- Both `pyshark_parser.py` and `pcapkit_parser.py` have been refactored to use this new factory method, ensuring consistent and robust `PcapRecord` instantiation.
- New unit tests have been added for the `from_parser_row` method to validate its coercion and default value logic.
- Existing tests have been updated to align with the new non-nullable model.