### PR TITLE
Add deterministic flow models and role derivation

### DIFF
--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -48,8 +48,8 @@ def _build_flow_id(key: FlowKey, start_ts: float) -> FlowId:
     """
 
     return FlowId(
-        f"{key.l4_proto}:{key.src_ip}:{key.src_port}->"
-        f"{key.dst_ip}:{key.dst_port}#{start_ts:.6f}"
+        f"{key.l4_proto}:{key.client_ip}:{key.client_port}->"
+        f"{key.server_ip}:{key.server_port}#{start_ts:.6f}"
     )
 
 

--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+"""Lightweight flow modelling utilities.
+
+This module defines simple data structures that identify a flow and expose
+minimal bookkeeping for packet direction and handshake detection.  The goal is
+to provide deterministic flow IDs that remain stable across runs while also
+capturing which endpoint acted as the client or server.
+"""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ..core.models import PcapRecord
+
+
+# ---------------------------------------------------------------------------
+# ``FlowKey`` and ``FlowId``
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FlowKey:
+    """Canonical 5‑tuple identifying a flow.
+
+    The tuple is ordered ``(client_ip, client_port, server_ip, server_port,
+    l4_proto)``.  ``Flow.from_packets`` determines which host is the client
+    using TCP SYN packets when available and otherwise falling back to the
+    lower port number.
+    """
+
+    src_ip: str
+    src_port: int
+    dst_ip: str
+    dst_port: int
+    l4_proto: str
+
+
+# ``FlowId`` is just a type alias for clarity.
+FlowId = str
+
+
+def _build_flow_id(key: FlowKey, start_ts: float) -> FlowId:
+    """Return a deterministic flow identifier.
+
+    ``start_ts`` is formatted with a fixed precision to ensure stable string
+    representations across Python versions.
+    """
+
+    return FlowId(
+        f"{key.l4_proto}:{key.src_ip}:{key.src_port}->"
+        f"{key.dst_ip}:{key.dst_port}#{start_ts:.6f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ``Flow`` dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Flow:
+    """Container holding packets that belong to a single network flow."""
+
+    id: FlowId
+    key: FlowKey
+    packets: List[PcapRecord] = field(default_factory=list)
+    start_ts: float = 0.0
+    end_ts: float = 0.0
+    protocol: str = ""
+    handshake_complete: bool = False
+    client_is_src: Optional[bool] = None
+    c2s_bytes: int = 0
+    c2s_packets: int = 0
+    s2c_bytes: int = 0
+    s2c_packets: int = 0
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_packets(cls, packets: List[PcapRecord]) -> "Flow":
+        """Create a :class:`Flow` from a list of packets.
+
+        The packets are analysed to determine client/server roles and basic
+        handshake information.  The resulting ``Flow`` has a deterministic
+        identifier derived from the canonicalised key and ``start_ts`` of the
+        capture.
+        """
+
+        if not packets:
+            raise ValueError("packets required")
+
+        packets_sorted = sorted(packets, key=lambda p: p.timestamp)
+        first = packets_sorted[0]
+        start_ts = first.timestamp
+        end_ts = packets_sorted[-1].timestamp
+        proto = first.protocol.upper()
+
+        (
+            client_ip,
+            client_port,
+            server_ip,
+            server_port,
+            client_is_src,
+        ) = cls._derive_roles(packets_sorted)
+
+        key = FlowKey(
+            src_ip=client_ip,
+            src_port=client_port,
+            dst_ip=server_ip,
+            dst_port=server_port,
+            l4_proto=proto,
+        )
+        fid = _build_flow_id(key, start_ts)
+
+        c2s_bytes = c2s_packets = s2c_bytes = s2c_packets = 0
+        syn = synack = final_ack = False
+
+        for pkt in packets_sorted:
+            if pkt.source_ip == client_ip and pkt.source_port == client_port:
+                c2s_packets += 1
+                c2s_bytes += pkt.packet_length
+                if pkt.protocol.upper() == "TCP":
+                    if pkt.tcp_flags_syn and not pkt.tcp_flags_ack:
+                        syn = True
+                    if synack and pkt.tcp_flags_ack and not pkt.tcp_flags_syn:
+                        final_ack = True
+            elif pkt.source_ip == server_ip and pkt.source_port == server_port:
+                s2c_packets += 1
+                s2c_bytes += pkt.packet_length
+                if pkt.protocol.upper() == "TCP" and pkt.tcp_flags_syn and pkt.tcp_flags_ack:
+                    synack = True
+
+        handshake_complete = syn and synack and final_ack
+
+        return cls(
+            id=fid,
+            key=key,
+            packets=packets_sorted,
+            start_ts=start_ts,
+            end_ts=end_ts,
+            protocol=proto,
+            handshake_complete=handshake_complete,
+            client_is_src=client_is_src,
+            c2s_bytes=c2s_bytes,
+            c2s_packets=c2s_packets,
+            s2c_bytes=s2c_bytes,
+            s2c_packets=s2c_packets,
+        )
+
+    # ------------------------------------------------------------------
+    # Static helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _derive_roles(packets: List[PcapRecord]) -> tuple[str, int, str, int, Optional[bool]]:
+        """Determine client/server endpoints for ``packets``.
+
+        The search prefers a TCP SYN packet which unambiguously marks the
+        client's direction.  If no such packet is present, the endpoint with
+        the lower port number is assumed to be the server.
+        """
+
+        first = packets[0]
+
+        for pkt in packets:
+            if (
+                pkt.protocol.upper() == "TCP"
+                and pkt.tcp_flags_syn
+                and not pkt.tcp_flags_ack
+            ):
+                client_ip = pkt.source_ip
+                client_port = pkt.source_port
+                server_ip = pkt.destination_ip
+                server_port = pkt.destination_port
+                client_is_src = (
+                    client_ip == first.source_ip and client_port == first.source_port
+                )
+                return (client_ip, client_port, server_ip, server_port, client_is_src)
+
+        # Fallback: lower port is assumed server
+        if first.source_port < first.destination_port:
+            # Source has the lower port so is assumed to be the server
+            client_ip, client_port = first.destination_ip, first.destination_port
+            server_ip, server_port = first.source_ip, first.source_port
+            client_is_src = False
+        elif first.source_port > first.destination_port:
+            client_ip, client_port = first.source_ip, first.source_port
+            server_ip, server_port = first.destination_ip, first.destination_port
+            client_is_src = True
+        else:  # ports are equal – direction unknown
+            client_ip, client_port = first.source_ip, first.source_port
+            server_ip, server_port = first.destination_ip, first.destination_port
+            client_is_src = None
+
+        return (client_ip, client_port, server_ip, server_port, client_is_src)
+
+
+__all__ = ["FlowKey", "FlowId", "Flow"]

--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -117,12 +117,13 @@ class Flow:
 
         c2s_bytes = c2s_packets = s2c_bytes = s2c_packets = 0
         syn = synack = final_ack = False
+        is_tcp = proto == "TCP"
 
         for pkt in packets_sorted:
             if pkt.source_ip == client_ip and pkt.source_port == client_port:
                 c2s_packets += 1
                 c2s_bytes += pkt.packet_length
-                if pkt.protocol.upper() == "TCP":
+                if is_tcp:
                     if pkt.tcp_flags_syn and not pkt.tcp_flags_ack:
                         syn = True
                     if synack and pkt.tcp_flags_ack and not pkt.tcp_flags_syn:
@@ -130,7 +131,7 @@ class Flow:
             elif pkt.source_ip == server_ip and pkt.source_port == server_port:
                 s2c_packets += 1
                 s2c_bytes += pkt.packet_length
-                if pkt.protocol.upper() == "TCP" and pkt.tcp_flags_syn and pkt.tcp_flags_ack:
+                if is_tcp and pkt.tcp_flags_syn and pkt.tcp_flags_ack:
                     synack = True
 
         handshake_complete = syn and synack and final_ack

--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -191,6 +191,8 @@ class Flow:
             server_ip, server_port = first.destination_ip, first.destination_port
             client_is_src = True
         else:  # ports are equal – direction unknown
+            # When ports are equal, we cannot determine client/server roles.
+            # The assignment below is arbitrary; client_is_src is set to None to indicate ambiguity.
             client_ip, client_port = first.source_ip, first.source_port
             server_ip, server_port = first.destination_ip, first.destination_port
             client_is_src = None

--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -29,10 +29,10 @@ class FlowKey:
     lower port number.
     """
 
-    src_ip: str
-    src_port: int
-    dst_ip: str
-    dst_port: int
+    client_ip: str
+    client_port: int
+    server_ip: str
+    server_port: int
     l4_proto: str
 
 

--- a/tests/unit/orchestrator/test_flow_models.py
+++ b/tests/unit/orchestrator/test_flow_models.py
@@ -1,0 +1,84 @@
+from pcap_tool.core.models import PcapRecord
+from pcap_tool.orchestrator.flow_models import Flow
+
+
+def _tcp_handshake_packets():
+    return [
+        PcapRecord(
+            timestamp=1.0,
+            source_ip="10.0.0.1",
+            destination_ip="10.0.0.2",
+            source_port=12345,
+            destination_port=80,
+            protocol="TCP",
+            tcp_flags_syn=True,
+            tcp_flags_ack=False,
+            packet_length=60,
+        ),
+        PcapRecord(
+            timestamp=1.1,
+            source_ip="10.0.0.2",
+            destination_ip="10.0.0.1",
+            source_port=80,
+            destination_port=12345,
+            protocol="TCP",
+            tcp_flags_syn=True,
+            tcp_flags_ack=True,
+            packet_length=60,
+        ),
+        PcapRecord(
+            timestamp=1.2,
+            source_ip="10.0.0.1",
+            destination_ip="10.0.0.2",
+            source_port=12345,
+            destination_port=80,
+            protocol="TCP",
+            tcp_flags_syn=False,
+            tcp_flags_ack=True,
+            packet_length=60,
+        ),
+    ]
+
+
+def test_flow_id_deterministic():
+    packets = _tcp_handshake_packets()
+    flow_a = Flow.from_packets(packets)
+    flow_b = Flow.from_packets(packets)
+    assert flow_a.id == flow_b.id
+    assert flow_a.key == flow_b.key
+    assert flow_a.id == "TCP:10.0.0.1:12345->10.0.0.2:80#1.000000"
+
+
+def test_role_derivation_prefers_syn():
+    packets = _tcp_handshake_packets()
+    flow = Flow.from_packets(packets)
+    assert flow.client_is_src is True
+    assert flow.key.src_ip == "10.0.0.1"
+    assert flow.key.dst_port == 80
+
+
+def test_role_derivation_falls_back_to_port():
+    packets = [
+        PcapRecord(
+            timestamp=2.0,
+            source_ip="10.0.0.2",
+            destination_ip="10.0.0.3",
+            source_port=53,
+            destination_port=15000,
+            protocol="UDP",
+            packet_length=50,
+        ),
+        PcapRecord(
+            timestamp=2.1,
+            source_ip="10.0.0.3",
+            destination_ip="10.0.0.2",
+            source_port=15000,
+            destination_port=53,
+            protocol="UDP",
+            packet_length=50,
+        ),
+    ]
+    flow = Flow.from_packets(packets)
+    assert flow.client_is_src is False
+    assert flow.key.src_ip == "10.0.0.3"
+    assert flow.key.dst_port == 53


### PR DESCRIPTION
## Summary
- implement FlowKey/FlowId with canonical client→server ordering
- add Flow dataclass tracking per-direction stats and handshake
- test deterministic flow IDs and client/server role detection

## Testing
- `flake8 src/ tests/`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a352968b388322aeceed39300d8276