### PR TITLE
Implement stateful flow builder with TCP teardown handling

### DIFF
--- a/src/pcap_tool/orchestrator/flow_builder.py
+++ b/src/pcap_tool/orchestrator/flow_builder.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+"""Utilities for turning packets into higher level flows.
+
+This module implements :class:`FlowBuilder`, a small stateful helper that
+aggregates :class:`~pcap_tool.core.models.PcapRecord` objects into
+``Flow`` instances.  Flows are emitted once they are deemed complete –
+when a TCP connection is closed via FIN/ACK, a RST is seen or the flow has
+been idle for longer than the configured timeout.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Tuple
+
+from ..core.models import PcapRecord
+from .flow_models import Flow
+
+
+# ---------------------------------------------------------------------------
+# Internal flow state tracking
+# ---------------------------------------------------------------------------
+
+
+Endpoint = Tuple[str, int]
+
+
+@dataclass
+class _FlowState:
+    """Bookkeeping for a single in‑flight flow."""
+
+    packets: List[PcapRecord] = field(default_factory=list)
+    last_seen: float = 0.0
+    fin_from: set[str] = field(default_factory=set)  # 'a' or 'b'
+    awaiting_final_ack: bool = False
+    rst_seen: bool = False
+
+
+# ---------------------------------------------------------------------------
+# ``FlowBuilder``
+# ---------------------------------------------------------------------------
+
+
+class FlowBuilder:
+    """Incrementally build network flows from packets.
+
+    Parameters
+    ----------
+    timeout_s:
+        Idle timeout in seconds after which a flow is considered finished
+        if no packets have been observed.
+    """
+
+    def __init__(self, timeout_s: float = 60) -> None:
+        self.timeout_s = timeout_s
+        self._flows: Dict[Tuple[str, Endpoint, Endpoint], _FlowState] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def observe(self, pkt: PcapRecord) -> Iterable[Flow]:
+        """Observe ``pkt`` and yield any flows that completed as a result.
+
+        The returned iterable may contain zero or more ``Flow`` objects.
+        Flows can be completed because the current packet closed a TCP
+        connection (FIN/ACK or RST) or because unrelated flows timed out
+        prior to handling this packet.
+        """
+
+        completed: List[Flow] = []
+
+        # First emit flows that have exceeded the idle timeout.
+        completed.extend(self._expire_idle(pkt.timestamp))
+
+        key, direction = self._key(pkt)
+        state = self._flows.get(key)
+        if state is None:
+            state = _FlowState()
+            self._flows[key] = state
+
+        state.packets.append(pkt)
+        state.last_seen = pkt.timestamp
+
+        if pkt.protocol.upper() == "TCP":
+            if pkt.tcp_flags_rst:
+                state.rst_seen = True
+                completed.append(self._finalise(key))
+                return completed
+
+            if pkt.tcp_flags_fin:
+                state.fin_from.add(direction)
+                # After both FINs we wait for the final ACK (ACK without FIN)
+                if len(state.fin_from) == 2:
+                    state.awaiting_final_ack = True
+
+            if (
+                state.awaiting_final_ack
+                and pkt.tcp_flags_ack
+                and not pkt.tcp_flags_fin
+                and not pkt.tcp_flags_rst
+            ):
+                completed.append(self._finalise(key))
+
+        return completed
+
+    def flush_all(self) -> Iterable[Flow]:
+        """Flush and return all currently tracked flows."""
+
+        completed: List[Flow] = []
+        for key in list(self._flows.keys()):
+            completed.append(self._finalise(key))
+        return completed
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _key(self, pkt: PcapRecord) -> Tuple[Tuple[str, Endpoint, Endpoint], str]:
+        """Return a canonical key for ``pkt`` and the packet direction.
+
+        The direction is ``'a'`` when the packet's source corresponds to the
+        first endpoint in the key and ``'b'`` otherwise.  Endpoints are
+        ordered to ensure packets from both directions map to the same key
+        regardless of who is the client or server.
+        """
+
+        proto = pkt.protocol.upper()
+        a: Endpoint = (pkt.source_ip, pkt.source_port)
+        b: Endpoint = (pkt.destination_ip, pkt.destination_port)
+        if a <= b:
+            key = (proto, a, b)
+            direction = "a"
+        else:
+            key = (proto, b, a)
+            direction = "b"
+        return key, direction
+
+    def _finalise(self, key: Tuple[str, Endpoint, Endpoint]) -> Flow:
+        """Create a :class:`Flow` from accumulated packets and remove state."""
+
+        state = self._flows.pop(key)
+        return Flow.from_packets(state.packets)
+
+    def _expire_idle(self, current_ts: float) -> List[Flow]:
+        """Emit flows whose last activity is older than ``timeout_s``."""
+
+        expired: List[Flow] = []
+        if not self._flows:
+            return expired
+
+        stale: List[Tuple[str, Endpoint, Endpoint]] = []
+        for key, state in self._flows.items():
+            if current_ts - state.last_seen > self.timeout_s:
+                stale.append(key)
+        for key in stale:
+            expired.append(self._finalise(key))
+        return expired
+
+
+__all__ = ["FlowBuilder"]

--- a/src/pcap_tool/orchestrator/flow_models.py
+++ b/src/pcap_tool/orchestrator/flow_models.py
@@ -35,6 +35,25 @@ class FlowKey:
     server_port: int
     l4_proto: str
 
+    # Backwards compatible attribute aliases -----------------------------
+    # Older parts of the codebase and tests used ``src_*``/``dst_*`` names.
+    # Expose them as read-only properties to avoid breaking imports.
+    @property
+    def src_ip(self) -> str:  # pragma: no cover - trivial accessors
+        return self.client_ip
+
+    @property
+    def src_port(self) -> int:  # pragma: no cover - trivial accessors
+        return self.client_port
+
+    @property
+    def dst_ip(self) -> str:  # pragma: no cover - trivial accessors
+        return self.server_ip
+
+    @property
+    def dst_port(self) -> int:  # pragma: no cover - trivial accessors
+        return self.server_port
+
 
 # ``FlowId`` is just a type alias for clarity.
 FlowId = str
@@ -107,10 +126,10 @@ class Flow:
         ) = cls._derive_roles(packets_sorted)
 
         key = FlowKey(
-            src_ip=client_ip,
-            src_port=client_port,
-            dst_ip=server_ip,
-            dst_port=server_port,
+            client_ip=client_ip,
+            client_port=client_port,
+            server_ip=server_ip,
+            server_port=server_port,
             l4_proto=proto,
         )
         fid = _build_flow_id(key, start_ts)

--- a/tests/unit/orchestrator/test_flow_builder_basic.py
+++ b/tests/unit/orchestrator/test_flow_builder_basic.py
@@ -1,0 +1,88 @@
+from pcap_tool.core.models import PcapRecord
+from pcap_tool.orchestrator.flow_builder import FlowBuilder
+
+
+def pkt(ts, src, dst, sport, dport, flags=""):
+    return PcapRecord(
+        timestamp=ts,
+        source_ip=src,
+        destination_ip=dst,
+        source_port=sport,
+        destination_port=dport,
+        protocol="TCP",
+        packet_length=1,
+        tcp_flags_syn="S" in flags,
+        tcp_flags_ack="A" in flags,
+        tcp_flags_fin="F" in flags,
+        tcp_flags_rst="R" in flags,
+    )
+
+
+def collect(builder, packets):
+    flows = []
+    for p in packets:
+        flows.extend(builder.observe(p))
+    return flows
+
+
+def test_fin_close_normal():
+    b = FlowBuilder(timeout_s=60)
+    packets = [
+        pkt(0, "1.1.1.1", "2.2.2.2", 1234, 80, "S"),
+        pkt(1, "2.2.2.2", "1.1.1.1", 80, 1234, "SA"),
+        pkt(2, "1.1.1.1", "2.2.2.2", 1234, 80, "A"),
+        pkt(3, "1.1.1.1", "2.2.2.2", 1234, 80, ""),
+        pkt(10, "1.1.1.1", "2.2.2.2", 1234, 80, "F"),
+        pkt(11, "2.2.2.2", "1.1.1.1", 80, 1234, "A"),
+        pkt(12, "2.2.2.2", "1.1.1.1", 80, 1234, "F"),
+        pkt(13, "1.1.1.1", "2.2.2.2", 1234, 80, "A"),
+    ]
+    flows = collect(b, packets)
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow.handshake_complete is True
+    assert flow.end_ts == 13
+    assert len(flow.packets) == len(packets)
+    assert b.flush_all() == []
+
+
+def test_rst_terminates_immediately():
+    b = FlowBuilder()
+    packets = [
+        pkt(0, "1.1.1.1", "2.2.2.2", 1234, 80, "S"),
+        pkt(1, "2.2.2.2", "1.1.1.1", 80, 1234, "R"),
+    ]
+    flows = collect(b, packets)
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow.handshake_complete is False
+    assert flow.end_ts == 1
+
+
+def test_idle_timeout_expires_flow():
+    b = FlowBuilder(timeout_s=60)
+    p1 = pkt(0, "1.1.1.1", "2.2.2.2", 1234, 80, "S")
+    b.observe(p1)
+    # Second packet belongs to another flow and is far in the future
+    p2 = pkt(70, "3.3.3.3", "4.4.4.4", 5555, 80, "S")
+    flows = b.observe(p2)
+    # The first flow should be timed out and emitted
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow.start_ts == 0
+    assert flow.end_ts == 0
+    # Flush remaining flow
+    remaining = b.flush_all()
+    assert len(remaining) == 1
+
+
+def test_syn_only_identifies_client():
+    b = FlowBuilder()
+    p = pkt(0, "10.0.0.1", "10.0.0.2", 12345, 80, "S")
+    b.observe(p)
+    flows = b.flush_all()
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow.key.client_ip == "10.0.0.1"
+    assert flow.key.server_port == 80
+    assert flow.handshake_complete is False


### PR DESCRIPTION
## Summary
- add `FlowBuilder` for assembling packets into completed flows
- fix `FlowKey` construction and expose src/dst aliases
- test flow builder for FIN, RST, idle timeout and SYN-only cases

## Testing
- `flake8 src/ tests/`
- `pytest -q`
- `pytest tests/unit/orchestrator/test_flow_builder_basic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a366e1c31c832297fed3a1cf9f93dd